### PR TITLE
Add centralized logging with timestamped files

### DIFF
--- a/app/logging_config.py
+++ b/app/logging_config.py
@@ -14,19 +14,29 @@ def _ensure_log_dir() -> Path:
     return _LOG_DIR
 
 
-def setup_logging() -> Path:
+def setup_logging() -> Path | None:
     """Configure application-wide logging.
 
     Creates a logs directory if it does not exist and configures the root logger
     with handlers that write both to stdout and to a timestamped log file.
+    If the directory or log file cannot be created, falls back to stdout-only
+    logging and returns ``None``.
     """
 
     if getattr(setup_logging, "_configured", False):
         return getattr(setup_logging, "_log_file")
 
-    log_dir = _ensure_log_dir()
+    try:
+        log_dir = _ensure_log_dir()
+    except OSError as exc:
+        log_dir = None
+        log_dir_error = exc
+    else:
+        log_dir_error = None
+
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    log_file = log_dir / f"{timestamp}.log"
+    log_file = None
+    file_error: OSError | None = None
 
     formatter = logging.Formatter(
         fmt="%(asctime)s [%(levelname)s] [%(name)s] %(message)s",
@@ -39,9 +49,16 @@ def setup_logging() -> Path:
     for handler in list(root_logger.handlers):
         root_logger.removeHandler(handler)
 
-    file_handler = logging.FileHandler(log_file, encoding="utf-8")
-    file_handler.setFormatter(formatter)
-    root_logger.addHandler(file_handler)
+    if log_dir is not None:
+        candidate_log_file = log_dir / f"{timestamp}.log"
+        try:
+            file_handler = logging.FileHandler(candidate_log_file, encoding="utf-8")
+        except OSError as exc:
+            file_error = exc
+        else:
+            file_handler.setFormatter(formatter)
+            root_logger.addHandler(file_handler)
+            log_file = candidate_log_file
 
     stream_handler = logging.StreamHandler()
     stream_handler.setFormatter(formatter)
@@ -49,7 +66,16 @@ def setup_logging() -> Path:
 
     setup_logging._configured = True
     setup_logging._log_file = log_file
-    root_logger.info("Logging initialized. Writing to %s", log_file)
+    if log_file is not None:
+        root_logger.info("Logging initialized. Writing to %s", log_file)
+    else:
+        reason = file_error or log_dir_error
+        if reason is not None:
+            root_logger.warning(
+                "Logging initialized without file handler due to: %s", reason
+            )
+        else:
+            root_logger.info("Logging initialized without file handler.")
     return log_file
 
 

--- a/app/logging_config.py
+++ b/app/logging_config.py
@@ -1,0 +1,57 @@
+"""Application logging configuration utilities."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from pathlib import Path
+
+_LOG_DIR = Path(__file__).resolve().parent.parent / "logs"
+
+
+def _ensure_log_dir() -> Path:
+    _LOG_DIR.mkdir(parents=True, exist_ok=True)
+    return _LOG_DIR
+
+
+def setup_logging() -> Path:
+    """Configure application-wide logging.
+
+    Creates a logs directory if it does not exist and configures the root logger
+    with handlers that write both to stdout and to a timestamped log file.
+    """
+
+    if getattr(setup_logging, "_configured", False):
+        return getattr(setup_logging, "_log_file")
+
+    log_dir = _ensure_log_dir()
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    log_file = log_dir / f"{timestamp}.log"
+
+    formatter = logging.Formatter(
+        fmt="%(asctime)s [%(levelname)s] [%(name)s] %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging.INFO)
+
+    for handler in list(root_logger.handlers):
+        root_logger.removeHandler(handler)
+
+    file_handler = logging.FileHandler(log_file, encoding="utf-8")
+    file_handler.setFormatter(formatter)
+    root_logger.addHandler(file_handler)
+
+    stream_handler = logging.StreamHandler()
+    stream_handler.setFormatter(formatter)
+    root_logger.addHandler(stream_handler)
+
+    setup_logging._configured = True
+    setup_logging._log_file = log_file
+    root_logger.info("Logging initialized. Writing to %s", log_file)
+    return log_file
+
+
+__all__ = ["setup_logging"]
+

--- a/app/main.py
+++ b/app/main.py
@@ -1,8 +1,15 @@
+import logging
+
 from fastapi import FastAPI
+
 from app.api.routes_request import router as request_router
 from app.api.routes_result import router as result_router
 from app.api.routes_reset import router as reset_router
+from app.logging_config import setup_logging
 from app.services.ticket_manager import TicketManager
+
+setup_logging()
+logger = logging.getLogger("app.main")
 
 ticket_manager = TicketManager()
 
@@ -18,3 +25,7 @@ app.include_router(reset_router, prefix="/reset", tags=["reset"])
 @app.get("/health", tags=["health"])
 def health():
     return {"status": "ok"}
+
+
+logger.info("Batch Load Balancer API application initialized.")
+

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,3 +1,4 @@
+import logging
 from functools import lru_cache
 from pathlib import Path
 from typing import Dict, Iterator, Tuple
@@ -5,6 +6,8 @@ from typing import Dict, Iterator, Tuple
 import yaml
 
 from app.models.device_config import DeviceConfig, VersionEntry
+
+logger = logging.getLogger("app.utils")
 
 
 @lru_cache()
@@ -15,7 +18,7 @@ def load_device() -> DeviceConfig:
         with open(config_path, "r", encoding="utf-8") as file:
             data = yaml.safe_load(file) or {}
     except Exception as e:
-        print(f"Error loading device.yaml: {e}")
+        logger.exception("Error loading device.yaml: %s", e)
         data = {}
 
     vendors = data.get("vendors", []) if isinstance(data, dict) else []


### PR DESCRIPTION
## Summary
- add a reusable logging configuration that writes timestamped log files to the logs/ directory and mirrors output to stdout
- initialize logging during FastAPI startup and replace ad-hoc prints across services with labeled logger calls
- improve diagnostics by ensuring load, machine allocation, and task processing flows emit informative tagged log entries

## Testing
- uv run python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68d8124702308333b1d6ae389afb9b51