### PR TITLE
Add standalone React ticket filtering UI

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,421 @@
+const { useMemo, useState } = React;
+const { createRoot } = ReactDOM;
+
+const tickets = [
+  {
+    id: '6b85e2c5-a33a-44ce-b6ea-9ca0d2aa9f4c',
+    status: 'completed',
+    vendor: 'cisco',
+    model: 'c8k',
+    version: '1.0',
+    enqueued_at: '2025-09-27 19:07:45.735329',
+    started_at: '2025-09-27 19:07:45.736822',
+    completed_at: '2025-09-27 19:07:51.748649',
+    machine: { serial: 'c8kSerial2', ip: '192.168.1.2', port: 6002 },
+    completed: true,
+    message: 'Ticket completed successfully',
+    result_data: 'Processed cisco - c8k',
+    raw_data: 'hostname core-switch\ninterface Gig0/0\n switchport access vlan 10\n spanning-tree portfast',
+  },
+  {
+    id: '1ec5ef1b-8287-406f-9810-a7a4360e71ef',
+    status: 'failed',
+    vendor: 'juniper',
+    model: 'qfx',
+    version: '4.2',
+    enqueued_at: '2025-09-21 08:12:01.101010',
+    started_at: '2025-09-21 08:12:05.221010',
+    completed_at: '2025-09-21 08:12:45.991010',
+    machine: { serial: 'jnpr-qfx-008', ip: '192.168.10.45', port: 7001 },
+    completed: false,
+    message: 'Rollback applied: invalid VLAN configuration',
+    result_data: 'VLAN validation failed on qfx',
+    raw_data: 'set vlans vlan-100 description "Edge VLAN"\nset vlans vlan-100 vlan-id 100\nset interfaces ge-0/0/1 unit 0 family ethernet-switching vlan members 100',
+  },
+  {
+    id: 'b7f4dc28-6d55-4ac0-8da0-b5e3461afcb9',
+    status: 'completed',
+    vendor: 'arista',
+    model: '7050X',
+    version: '2.6',
+    enqueued_at: '2025-08-11 13:02:22.000145',
+    started_at: '2025-08-11 13:02:24.000145',
+    completed_at: '2025-08-11 13:05:30.000145',
+    machine: { serial: 'ar7050x-21', ip: '10.10.10.21', port: 7002 },
+    completed: true,
+    message: 'Pushed QoS template to all uplinks',
+    result_data: 'QoS profile applied to arista 7050X',
+    raw_data: 'interface Ethernet1\n service-policy input QOS-IN\n service-policy output QOS-OUT',
+  },
+  {
+    id: '9d27c1b5-53dc-4a5c-9312-b4222a2769f8',
+    status: 'running',
+    vendor: 'cisco',
+    model: 'n9k',
+    version: '3.1',
+    enqueued_at: '2025-09-29 02:45:00.000010',
+    started_at: '2025-09-29 02:45:05.000010',
+    completed_at: '',
+    machine: { serial: 'n9k-core-44', ip: '172.16.0.12', port: 6005 },
+    completed: false,
+    message: 'Ticket is currently executing',
+    result_data: 'Executing maintenance workflow',
+    raw_data: 'feature interface-vlan\ninterface Vlan200\n ip address 172.16.200.1/24',
+  },
+  {
+    id: '3a12bc48-b7c2-4f92-9f6e-17e140987654',
+    status: 'completed',
+    vendor: 'hpe',
+    model: 'aruba-8400',
+    version: '10.3',
+    enqueued_at: '2025-09-18 11:55:45.444321',
+    started_at: '2025-09-18 11:55:47.444321',
+    completed_at: '2025-09-18 11:57:12.444321',
+    machine: { serial: 'aruba-8400-07', ip: '10.0.50.7', port: 7011 },
+    completed: true,
+    message: 'Updated wireless controller routes',
+    result_data: 'Aruba routing policy synced',
+    raw_data: 'router ospf 1\n network 10.0.50.0 0.0.0.255 area 0\n passive-interface default\n no passive-interface vlan 10',
+  },
+];
+
+const nestedValue = (object, path) =>
+  path.split('.').reduce((acc, key) => (acc && acc[key] !== undefined ? acc[key] : undefined), object);
+
+const toDate = (value) => (value ? new Date(value.replace(' ', 'T')) : null);
+
+const uniqueValues = (key) => {
+  const seen = new Set();
+  tickets.forEach((ticket) => {
+    const value = nestedValue(ticket, key);
+    if (value !== undefined && value !== null && value !== '') {
+      seen.add(String(value));
+    }
+  });
+  return Array.from(seen).sort((a, b) => a.localeCompare(b, 'zh-Hant'));
+};
+
+const fieldConfigs = [
+  { key: 'id', label: 'Ticket ID', type: 'text' },
+  { key: 'status', label: '狀態', type: 'select', options: uniqueValues('status') },
+  { key: 'vendor', label: '廠商', type: 'select', options: uniqueValues('vendor') },
+  { key: 'model', label: '型號', type: 'text' },
+  { key: 'version', label: '版本', type: 'text' },
+  { key: 'machine.serial', label: '設備序號', type: 'text' },
+  { key: 'machine.ip', label: '設備 IP', type: 'text' },
+  { key: 'machine.port', label: '設備連接埠', type: 'number' },
+];
+
+const dateFields = [
+  { key: 'enqueued_at', label: '加入佇列時間' },
+  { key: 'started_at', label: '開始時間' },
+  { key: 'completed_at', label: '完成時間' },
+];
+
+const TicketFilters = ({
+  activeFields,
+  onToggleField,
+  criteria,
+  onCriteriaChange,
+  dateRanges,
+  onDateChange,
+  resultQuery,
+  rawQuery,
+  onResultQueryChange,
+  onRawQueryChange,
+  onReset,
+}) => (
+  <div className="filter-card">
+    <div className="app-header">
+      <h1>Ticket 智慧篩選</h1>
+      <p>選取條件、輸入內容，即可即時收斂符合條件的票單。</p>
+    </div>
+
+    <section>
+      <h2 className="section-title" style={{ fontSize: '1rem', marginBottom: '14px' }}>
+        選擇篩選欄位
+      </h2>
+      <div className="field-selector">
+        {fieldConfigs.map((field) => {
+          const isActive = activeFields.includes(field.key);
+          return (
+            <label key={field.key} className={`field-toggle${isActive ? ' active' : ''}`}>
+              <input
+                type="checkbox"
+                checked={isActive}
+                onChange={() => onToggleField(field.key)}
+              />
+              <span>{field.label}</span>
+            </label>
+          );
+        })}
+      </div>
+    </section>
+
+    <section className="field-inputs">
+      {activeFields.map((key) => {
+        const field = fieldConfigs.find((item) => item.key === key);
+        if (!field) return null;
+        const value = criteria[key] ?? '';
+        return (
+          <div key={key} className="input-group">
+            <label htmlFor={`input-${key}`}>{field.label}</label>
+            {field.type === 'select' ? (
+              <select
+                id={`input-${key}`}
+                value={value}
+                onChange={(event) => onCriteriaChange(key, event.target.value)}
+              >
+                <option value="">全部</option>
+                {field.options.map((option) => (
+                  <option key={option} value={option}>
+                    {option}
+                  </option>
+                ))}
+              </select>
+            ) : (
+              <input
+                id={`input-${key}`}
+                type={field.type}
+                value={value}
+                onChange={(event) => onCriteriaChange(key, event.target.value)}
+                placeholder={`輸入${field.label}`}
+              />
+            )}
+          </div>
+        );
+      })}
+
+      {dateFields.map(({ key, label }) => (
+        <div key={key} className="input-group">
+          <label>{label}</label>
+          <div style={{ display: 'flex', gap: '12px' }}>
+            <input
+              type="datetime-local"
+              value={dateRanges[key]?.from ?? ''}
+              onChange={(event) => onDateChange(key, 'from', event.target.value)}
+            />
+            <input
+              type="datetime-local"
+              value={dateRanges[key]?.to ?? ''}
+              onChange={(event) => onDateChange(key, 'to', event.target.value)}
+            />
+          </div>
+        </div>
+      ))}
+
+      <div className="input-group" style={{ gridColumn: '1 / -1' }}>
+        <label htmlFor="result-query">Result Data</label>
+        <textarea
+          id="result-query"
+          rows={3}
+          placeholder="輸入結果文字片段"
+          value={resultQuery}
+          onChange={(event) => onResultQueryChange(event.target.value)}
+        />
+      </div>
+
+      <div className="input-group" style={{ gridColumn: '1 / -1' }}>
+        <label htmlFor="raw-query">Switch Config (Raw Data)</label>
+        <textarea
+          id="raw-query"
+          rows={3}
+          placeholder="輸入設定文字片段"
+          value={rawQuery}
+          onChange={(event) => onRawQueryChange(event.target.value)}
+        />
+      </div>
+    </section>
+
+    <div className="action-row">
+      <button className="button secondary" type="button" onClick={onReset}>
+        清除條件
+      </button>
+    </div>
+  </div>
+);
+
+const TicketCard = ({ ticket, onSelect }) => (
+  <article className="ticket-card" onClick={() => onSelect(ticket)}>
+    <h2>{ticket.vendor.toUpperCase()} · {ticket.model}</h2>
+    <div className="ticket-meta">
+      <span>ID：{ticket.id}</span>
+      <span>狀態：{ticket.status}</span>
+      <span>版本：{ticket.version}</span>
+      <span>加入佇列：{ticket.enqueued_at || '—'}</span>
+      <span>開始時間：{ticket.started_at || '—'}</span>
+      <span>完成時間：{ticket.completed_at || '—'}</span>
+      <span>設備序號：{ticket.machine.serial}</span>
+      <span>設備位址：{ticket.machine.ip}:{ticket.machine.port}</span>
+    </div>
+  </article>
+);
+
+const TicketModal = ({ ticket, onClose }) => {
+  const [activeTab, setActiveTab] = useState('raw');
+
+  if (!ticket) return null;
+
+  return (
+    <div className="modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="ticket-modal-title">
+      <div className="modal">
+        <div className="modal-header">
+          <h3 id="ticket-modal-title">{ticket.vendor.toUpperCase()} · {ticket.model}</h3>
+          <button className="modal-close" onClick={onClose} aria-label="關閉">
+            ×
+          </button>
+        </div>
+        <div className="modal-tabs">
+          <button
+            className={`tab-button${activeTab === 'raw' ? ' active' : ''}`}
+            onClick={() => setActiveTab('raw')}
+            type="button"
+          >
+            Switch Config
+          </button>
+          <button
+            className={`tab-button${activeTab === 'result' ? ' active' : ''}`}
+            onClick={() => setActiveTab('result')}
+            type="button"
+          >
+            Result Data
+          </button>
+        </div>
+        <div className="modal-content">
+          {activeTab === 'raw' ? ticket.raw_data : ticket.result_data}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const App = () => {
+  const [activeFields, setActiveFields] = useState(['status', 'vendor']);
+  const [criteria, setCriteria] = useState({});
+  const [dateRanges, setDateRanges] = useState({
+    enqueued_at: { from: '', to: '' },
+    started_at: { from: '', to: '' },
+    completed_at: { from: '', to: '' },
+  });
+  const [resultQuery, setResultQuery] = useState('');
+  const [rawQuery, setRawQuery] = useState('');
+  const [selectedTicket, setSelectedTicket] = useState(null);
+
+  const toggleField = (key) => {
+    setActiveFields((prev) =>
+      prev.includes(key) ? prev.filter((item) => item !== key) : [...prev, key]
+    );
+  };
+
+  const handleCriteriaChange = (key, value) => {
+    setCriteria((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const handleDateChange = (key, bound, value) => {
+    setDateRanges((prev) => ({
+      ...prev,
+      [key]: { ...prev[key], [bound]: value },
+    }));
+  };
+
+  const resetFilters = () => {
+    setActiveFields([]);
+    setCriteria({});
+    setDateRanges({
+      enqueued_at: { from: '', to: '' },
+      started_at: { from: '', to: '' },
+      completed_at: { from: '', to: '' },
+    });
+    setResultQuery('');
+    setRawQuery('');
+  };
+
+  const filteredTickets = useMemo(() => {
+    return tickets.filter((ticket) => {
+      for (const key of activeFields) {
+        const query = (criteria[key] ?? '').trim();
+        if (!query) continue;
+        const value = nestedValue(ticket, key);
+        if (value === undefined || value === null) {
+          return false;
+        }
+        if (typeof value === 'number') {
+          if (Number(query) !== value) {
+            return false;
+          }
+        } else {
+          if (!String(value).toLowerCase().includes(query.toLowerCase())) {
+            return false;
+          }
+        }
+      }
+
+      for (const { key } of dateFields) {
+        const range = dateRanges[key];
+        if (!range) continue;
+        const { from, to } = range;
+        if (!from && !to) continue;
+        const value = nestedValue(ticket, key);
+        const dateValue = toDate(value);
+        if (!dateValue) return false;
+        if (from) {
+          const fromDate = new Date(from);
+          if (dateValue < fromDate) return false;
+        }
+        if (to) {
+          const toDateValue = new Date(to);
+          if (dateValue > toDateValue) return false;
+        }
+      }
+
+      if (resultQuery.trim()) {
+        if (!ticket.result_data || !ticket.result_data.toLowerCase().includes(resultQuery.trim().toLowerCase())) {
+          return false;
+        }
+      }
+
+      if (rawQuery.trim()) {
+        if (!ticket.raw_data || !ticket.raw_data.toLowerCase().includes(rawQuery.trim().toLowerCase())) {
+          return false;
+        }
+      }
+
+      return true;
+    });
+  }, [activeFields, criteria, dateRanges, resultQuery, rawQuery]);
+
+  return (
+    <div>
+      <TicketFilters
+        activeFields={activeFields}
+        onToggleField={toggleField}
+        criteria={criteria}
+        onCriteriaChange={handleCriteriaChange}
+        dateRanges={dateRanges}
+        onDateChange={handleDateChange}
+        resultQuery={resultQuery}
+        rawQuery={rawQuery}
+        onResultQueryChange={setResultQuery}
+        onRawQueryChange={setRawQuery}
+        onReset={resetFilters}
+      />
+
+      {filteredTickets.length > 0 ? (
+        <div className="ticket-grid">
+          {filteredTickets.map((ticket) => (
+            <TicketCard key={ticket.id} ticket={ticket} onSelect={setSelectedTicket} />
+          ))}
+        </div>
+      ) : (
+        <div className="empty-state">沒有符合條件的票單，請調整篩選條件。</div>
+      )}
+
+      {selectedTicket && (
+        <TicketModal ticket={selectedTicket} onClose={() => setSelectedTicket(null)} />
+      )}
+    </div>
+  );
+};
+
+const root = createRoot(document.getElementById('root'));
+root.render(<App />);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Ticket 篩選面板</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.production.min.js" crossorigin></script>
+    <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.production.min.js" crossorigin></script>
+    <script src="https://cdn.jsdelivr.net/npm/@babel/standalone@7.22.20/babel.min.js"></script>
+    <script type="text/babel" data-presets="env,react" src="app.js"></script>
+  </body>
+</html>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,0 +1,314 @@
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;700&display=swap');
+
+:root {
+  --tsmc-red: #e60012;
+  --tsmc-dark: #1f1f1f;
+  --tsmc-gray: #6c6c6c;
+  --tsmc-light: #f5f5f5;
+  --tsmc-silver: #d9d9d9;
+  --card-radius: 16px;
+  --shadow: 0 18px 40px -20px rgba(30, 30, 30, 0.4);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Noto Sans TC', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: radial-gradient(circle at top, rgba(230, 0, 18, 0.08), transparent 55%),
+    linear-gradient(180deg, #ffffff 0%, #f0f1f4 100%);
+  color: var(--tsmc-dark);
+  min-height: 100vh;
+}
+
+#root {
+  padding: 40px clamp(16px, 4vw, 72px);
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.app-header {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 24px;
+}
+
+.app-header h1 {
+  font-size: clamp(1.8rem, 2.4vw, 2.6rem);
+  font-weight: 700;
+  margin: 0;
+}
+
+.app-header p {
+  margin: 0;
+  color: var(--tsmc-gray);
+  font-size: 0.95rem;
+}
+
+.filter-card {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: var(--card-radius);
+  padding: clamp(20px, 3vw, 32px);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(12px);
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+
+.field-selector {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 12px 18px;
+}
+
+.field-toggle {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: var(--tsmc-light);
+  border: 1px solid transparent;
+  transition: border 0.2s ease, transform 0.2s ease;
+  cursor: pointer;
+}
+
+.field-toggle input {
+  accent-color: var(--tsmc-red);
+}
+
+.field-toggle.active {
+  border-color: var(--tsmc-red);
+  transform: translateY(-1px);
+  box-shadow: 0 10px 22px -18px rgba(230, 0, 18, 0.8);
+}
+
+.field-toggle span {
+  font-weight: 500;
+}
+
+.section-title {
+  font-weight: 700;
+  letter-spacing: 0.6px;
+  color: var(--tsmc-dark);
+}
+
+.field-inputs {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 18px;
+}
+
+.input-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.input-group label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--tsmc-gray);
+}
+
+.input-group input,
+.input-group select,
+.input-group textarea {
+  border: 1px solid var(--tsmc-silver);
+  border-radius: 12px;
+  padding: 12px 14px;
+  font-size: 0.95rem;
+  background: #fff;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.input-group input:focus,
+.input-group select:focus,
+.input-group textarea:focus {
+  outline: none;
+  border-color: var(--tsmc-red);
+  box-shadow: 0 0 0 4px rgba(230, 0, 18, 0.15);
+}
+
+.action-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: flex-end;
+}
+
+.button {
+  padding: 12px 20px;
+  border-radius: 999px;
+  border: none;
+  font-weight: 600;
+  letter-spacing: 0.4px;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.button.primary {
+  background: var(--tsmc-red);
+  color: #fff;
+  box-shadow: 0 12px 24px -12px rgba(230, 0, 18, 0.65);
+}
+
+.button.secondary {
+  background: transparent;
+  color: var(--tsmc-red);
+  border: 1px solid var(--tsmc-red);
+}
+
+.button:hover {
+  transform: translateY(-1px);
+}
+
+.ticket-grid {
+  margin-top: 36px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 24px;
+}
+
+.ticket-card {
+  background: rgba(255, 255, 255, 0.96);
+  border-radius: var(--card-radius);
+  padding: 20px;
+  box-shadow: var(--shadow);
+  border: 1px solid rgba(230, 0, 18, 0.08);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.ticket-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 22px 40px -22px rgba(230, 0, 18, 0.6);
+}
+
+.ticket-card h2 {
+  margin: 0 0 12px;
+  font-size: 1.1rem;
+  color: var(--tsmc-dark);
+}
+
+.ticket-meta {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 6px;
+  font-size: 0.9rem;
+}
+
+.ticket-meta span {
+  color: var(--tsmc-gray);
+}
+
+.empty-state {
+  margin-top: 48px;
+  padding: 40px;
+  border-radius: var(--card-radius);
+  background: rgba(255, 255, 255, 0.8);
+  text-align: center;
+  color: var(--tsmc-gray);
+  border: 1px dashed var(--tsmc-silver);
+}
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(17, 17, 17, 0.52);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 24px;
+  z-index: 999;
+}
+
+.modal {
+  background: #fff;
+  border-radius: 20px;
+  max-width: 640px;
+  width: min(90vw, 640px);
+  box-shadow: 0 30px 60px -30px rgba(0, 0, 0, 0.35);
+  overflow: hidden;
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px 24px;
+  border-bottom: 1px solid var(--tsmc-silver);
+}
+
+.modal-header h3 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.modal-close {
+  border: none;
+  background: rgba(230, 0, 18, 0.1);
+  color: var(--tsmc-red);
+  border-radius: 999px;
+  width: 36px;
+  height: 36px;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.modal-close:hover {
+  background: rgba(230, 0, 18, 0.18);
+}
+
+.modal-tabs {
+  display: flex;
+  gap: 6px;
+  padding: 0 24px;
+  border-bottom: 1px solid var(--tsmc-silver);
+}
+
+.tab-button {
+  flex: 1;
+  border: none;
+  padding: 14px 0;
+  font-weight: 600;
+  background: transparent;
+  color: var(--tsmc-gray);
+  border-bottom: 3px solid transparent;
+  cursor: pointer;
+  transition: color 0.2s ease, border-color 0.2s ease;
+}
+
+.tab-button.active {
+  color: var(--tsmc-red);
+  border-color: var(--tsmc-red);
+}
+
+.modal-content {
+  padding: 24px;
+  max-height: 400px;
+  overflow-y: auto;
+  line-height: 1.55;
+  white-space: pre-wrap;
+  background: var(--tsmc-light);
+}
+
+@media (max-width: 768px) {
+  #root {
+    padding: 24px clamp(16px, 6vw, 24px);
+  }
+
+  .field-selector {
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  }
+
+  .modal {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- add a standalone React-powered ticket filtering page with CDN-hosted dependencies
- implement configurable filters, date range search, and content matching for result and raw data
- style the grid and modal interface with a modern TSMC-inspired palette, including tabbed detail views

## Testing
- not run (frontend-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d83842b2ac833397e6d41702810e26