### PR TITLE
fix: align ticket search inputs with ticket model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,6 +151,10 @@ venv.bak/
 # Rope project settings
 .ropeproject
 
+# Frontend build artifacts
+frontend/node_modules/
+frontend/dist/
+
 # mkdocs documentation
 /site
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,33 @@ A FastAPI-based load balancer for switch testbed management.
 
 本專案使用 [uv](https://docs.astral.sh/uv/) 作為包管理工具。
 
+### 前端 (React) 開發
+
+專案根目錄下的 `frontend/` 目錄提供 ticket 查詢介面的 React 應用程式，採用 Vite 建置。
+
+1. 安裝依賴：
+
+   ```bash
+   cd frontend
+   npm install
+   ```
+
+2. 啟動開發伺服器：
+
+   ```bash
+   npm run dev
+   ```
+
+   預設於 http://localhost:5173 執行，可透過 `VITE_API_BASE_URL` 環境變數指定後端 API 位址。
+
+3. 打包建置：
+
+   ```bash
+   npm run build
+   ```
+
+前端會透過 `/tickets/search` API 與後端整合，請確保後端服務已啟動並可供存取。
+
 ### 前置需求
 
 確保您已安裝 `uv`：
@@ -92,7 +119,8 @@ app/
 ├── api/             # API 路由
 │   ├── routes_request.py
 │   ├── routes_reset.py
-│   └── routes_result.py
+│   ├── routes_result.py
+│   └── routes_tickets.py
 ├── models/          # 資料模型
 │   ├── machine.py
 │   └── ticket.py

--- a/app/api/routes_tickets.py
+++ b/app/api/routes_tickets.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+from dataclasses import fields as dataclass_fields
+from datetime import datetime
+from enum import Enum
+from typing import Dict, List, Optional, Set, Tuple, cast
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.encoders import jsonable_encoder
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+
+from app.models.machine import Machine
+from app.models.ticket import Ticket
+from app.services.ticket_manager import TicketManager
+
+
+def _build_allowed_fields() -> Tuple[str, ...]:
+    ticket_fields = tuple(Ticket.model_fields.keys())
+    machine_allowed: Set[str] = {"serial", "ip", "port"}
+    machine_fields = tuple(
+        f"machine.{field.name}"
+        for field in dataclass_fields(Machine)
+        if field.name in machine_allowed
+    )
+    ordered = (*ticket_fields, *machine_fields)
+    # remove duplicates while preserving order
+    seen: Set[str] = set()
+    result: List[str] = []
+    for name in ordered:
+        if name not in seen:
+            seen.add(name)
+            result.append(name)
+    return tuple(result)
+
+
+ALLOWED_FIELDS = _build_allowed_fields()
+DATE_FIELD_NAMES = tuple(
+    field for field in ("enqueued_at", "started_at", "completed_at") if field in Ticket.model_fields
+)
+
+
+class DateRange(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    from_: Optional[datetime] = Field(default=None, alias="from")
+    to: Optional[datetime] = None
+
+
+class TicketSearchRequest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    active_fields: List[str] = Field(default_factory=list, alias="activeFields")
+    field_values: Dict[str, str] = Field(default_factory=dict, alias="fieldValues")
+    date_ranges: Dict[str, DateRange] = Field(default_factory=dict, alias="dateRanges")
+    result_data: Optional[str] = Field(default=None, alias="resultData")
+    raw_data: Optional[str] = Field(default=None, alias="rawData")
+
+    @model_validator(mode="after")
+    def validate_fields(self) -> "TicketSearchRequest":
+        invalid_active = [field for field in self.active_fields if field not in ALLOWED_FIELDS]
+        invalid_values = [field for field in self.field_values if field not in ALLOWED_FIELDS]
+        invalid_dates = [field for field in self.date_ranges if field not in DATE_FIELD_NAMES]
+
+        if invalid_active or invalid_values or invalid_dates:
+            detail = {
+                "active_fields": invalid_active,
+                "field_values": invalid_values,
+                "date_ranges": invalid_dates,
+            }
+            raise ValueError(f"Invalid ticket fields supplied: {detail}")
+
+        return self
+
+
+def _build_ticket_model(ticket_data: dict) -> Optional[Ticket]:
+    payload = {key: ticket_data.get(key) for key in Ticket.model_fields}
+    machine_data = ticket_data.get("machine")
+    if isinstance(machine_data, dict):
+        try:
+            payload["machine"] = Machine(
+                vendor=machine_data.get("vendor") or ticket_data.get("vendor", ""),
+                model=machine_data.get("model") or ticket_data.get("model", ""),
+                version=str(machine_data.get("version") or ticket_data.get("version", "")),
+                ip=machine_data.get("ip") or "",
+                port=int(machine_data.get("port") or 0),
+                serial=machine_data.get("serial") or "",
+                ticket_id=machine_data.get("ticket_id"),
+            )
+        except (TypeError, ValueError):
+            payload["machine"] = None
+    try:
+        return Ticket.model_validate(payload)
+    except ValidationError:
+        return None
+
+
+def _get_field_value(ticket: Ticket, source: dict, field: str) -> Optional[str]:
+    if field not in ALLOWED_FIELDS:
+        return None
+
+    if "." in field:
+        base, nested = field.split(".", 1)
+        if base == "machine":
+            machine_source = source.get("machine") or {}
+            value = machine_source.get(nested)
+            return str(value) if value is not None else None
+        value = getattr(ticket, base, None)
+        if value is None:
+            return None
+        nested_value = getattr(value, nested, None)
+        if nested_value is None:
+            return None
+        return str(nested_value)
+
+    value = getattr(ticket, field, None)
+    if value is None:
+        return None
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return str(value)
+
+
+def _contains(value: Optional[str], expected: Optional[str]) -> bool:
+    if not expected:
+        return True
+    if not value:
+        return False
+    return expected.lower() in value.lower()
+
+
+def _normalize_search_term(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    trimmed = value.strip()
+    return trimmed or None
+
+
+def _matches(ticket: Ticket, source: dict, payload: TicketSearchRequest) -> bool:
+    for field in payload.active_fields:
+        expected = payload.field_values.get(field, "").strip()
+        if expected and not _contains(_get_field_value(ticket, source, field), expected):
+            return False
+
+    for field, value in payload.field_values.items():
+        if field in payload.active_fields:
+            continue
+        if value.strip() and not _contains(_get_field_value(ticket, source, field), value.strip()):
+            return False
+
+    for field_name, date_range in payload.date_ranges.items():
+        if field_name not in DATE_FIELD_NAMES:
+            return False
+        if not date_range.from_ and not date_range.to:
+            continue
+        target_value = getattr(ticket, field_name, None)
+        if not isinstance(target_value, datetime):
+            return False
+        if date_range.from_ and target_value < date_range.from_:
+            return False
+        if date_range.to and target_value > date_range.to:
+            return False
+
+    if not _contains(ticket.result_data, _normalize_search_term(payload.result_data)):
+        return False
+
+    if not _contains(source.get("raw_data"), _normalize_search_term(payload.raw_data)):
+        return False
+
+    return True
+
+
+router = APIRouter()
+
+
+@router.post("/search")
+def search_tickets(payload: TicketSearchRequest, request: Request) -> dict:
+    ticket_manager = request.app.state.ticket_manager
+    if not ticket_manager:
+        raise HTTPException(status_code=500, detail="Ticket manager is not initialized")
+
+    ticket_manager = cast(TicketManager, ticket_manager)
+    tickets = ticket_manager.list_tickets()
+    matched: List[dict] = []
+    for ticket_data in tickets:
+        ticket_model = _build_ticket_model(ticket_data)
+        if not ticket_model:
+            continue
+        if _matches(ticket_model, ticket_data, payload):
+            matched.append(ticket_data)
+
+    return {"tickets": jsonable_encoder(matched)}

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,7 @@
 import logging
 
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
 from app.api.routes_request import router as request_router
 from app.api.routes_reset import router as reset_router
@@ -15,7 +16,13 @@ logger = logging.getLogger("app.main")
 ticket_manager = TicketManager()
 
 app = FastAPI(title="Batch Load Balancer API", version="1.0.0")
-
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 app.state.ticket_manager = ticket_manager
 
 app.include_router(request_router, prefix="/request", tags=["request"])

--- a/app/main.py
+++ b/app/main.py
@@ -3,8 +3,9 @@ import logging
 from fastapi import FastAPI
 
 from app.api.routes_request import router as request_router
-from app.api.routes_result import router as result_router
 from app.api.routes_reset import router as reset_router
+from app.api.routes_result import router as result_router
+from app.api.routes_tickets import router as tickets_router
 from app.logging_config import setup_logging
 from app.services.ticket_manager import TicketManager
 
@@ -20,6 +21,7 @@ app.state.ticket_manager = ticket_manager
 app.include_router(request_router, prefix="/request", tags=["request"])
 app.include_router(result_router, prefix="/result", tags=["result"])
 app.include_router(reset_router, prefix="/reset", tags=["reset"])
+app.include_router(tickets_router, prefix="/tickets", tags=["tickets"])
 
 
 @app.get("/health", tags=["health"])

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Switch Ticket Explorer</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "switch-testbed-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.37",
+    "@types/react-dom": "^18.2.15",
+    "@vitejs/plugin-react": "^4.2.1",
+    "typescript": "^5.3.3",
+    "vite": "^5.1.0"
+  }
+}

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,0 +1,75 @@
+.layout {
+  min-height: 100vh;
+  display: grid;
+  gap: 2.5rem;
+  padding: clamp(1.5rem, 4vw, 3rem);
+  background: radial-gradient(circle at top left, rgba(239, 51, 64, 0.12), transparent 45%),
+    radial-gradient(circle at 80% 20%, rgba(0, 102, 204, 0.18), transparent 50%),
+    linear-gradient(180deg, #0f172a, #090b1a 55%, #0c172c 100%);
+}
+
+.results {
+  background: rgba(255, 255, 255, 0.94);
+  border-radius: 32px;
+  padding: clamp(1.75rem, 3vw, 2.5rem);
+  box-shadow: 0 30px 60px rgba(6, 11, 22, 0.28);
+  display: grid;
+  gap: 1.75rem;
+}
+
+.results__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.results__header h2 {
+  margin: 0 0 0.25rem;
+  font-size: clamp(1.4rem, 2vw, 1.8rem);
+  color: var(--ink-strong);
+}
+
+.results__header p {
+  margin: 0;
+  color: var(--ink-muted);
+}
+
+.card-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.alert {
+  padding: 1rem 1.25rem;
+  border-radius: 16px;
+  background: rgba(239, 51, 64, 0.1);
+  color: var(--tsmc-red);
+  font-weight: 600;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.4rem 1rem;
+  border-radius: 999px;
+  background: rgba(0, 102, 204, 0.14);
+  color: var(--tsmc-blue);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.empty {
+  margin: 0;
+  color: var(--ink-muted);
+  font-style: italic;
+}
+
+@media (min-width: 1280px) {
+  .layout {
+    grid-template-columns: 420px 1fr;
+    align-items: start;
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,77 @@
+import { useState } from "react";
+import { FilterPanel } from "./components/FilterPanel";
+import { TicketCard } from "./components/TicketCard";
+import { TicketModal } from "./components/TicketModal";
+import { useTickets } from "./hooks/useTickets";
+import type { FilterState, Ticket } from "./types";
+import "./App.css";
+
+const initialFilters: FilterState = {
+  activeFields: [],
+  fieldValues: {},
+  dateRanges: {
+    enqueued_at: {},
+    started_at: {},
+    completed_at: {}
+  },
+  resultData: "",
+  rawData: "",
+};
+
+function cloneFilters(filters: FilterState): FilterState {
+  return {
+    activeFields: [...filters.activeFields],
+    fieldValues: { ...filters.fieldValues },
+    dateRanges: Object.fromEntries(
+      Object.entries(filters.dateRanges).map(([key, range]) => [key, { ...range }])
+    ) as FilterState["dateRanges"],
+    resultData: filters.resultData,
+    rawData: filters.rawData,
+  };
+}
+
+export default function App() {
+  const [pendingFilters, setPendingFilters] = useState<FilterState>(initialFilters);
+  const [appliedFilters, setAppliedFilters] = useState<FilterState>(initialFilters);
+  const { tickets, loading, error } = useTickets(appliedFilters);
+  const [selectedTicket, setSelectedTicket] = useState<Ticket | null>(null);
+
+  const submitFilters = () => {
+    setAppliedFilters(cloneFilters(pendingFilters));
+  };
+
+  return (
+    <div className="layout">
+      <FilterPanel
+        filters={pendingFilters}
+        onChange={setPendingFilters}
+        onSubmit={submitFilters}
+        submitting={loading}
+      />
+
+      <section className="results">
+        <header className="results__header">
+          <div>
+            <h2>搜尋結果</h2>
+            <p>共 {tickets.length} 筆符合條件的 ticket。</p>
+          </div>
+          {loading && <span className="pill">載入中...</span>}
+        </header>
+
+        {error && <div className="alert">{error}</div>}
+
+        {!loading && tickets.length === 0 && (
+          <p className="empty">找不到符合條件的 ticket，請調整搜尋條件。</p>
+        )}
+
+        <div className="card-grid">
+          {tickets.map((ticket) => (
+            <TicketCard key={ticket.id} ticket={ticket} onClick={setSelectedTicket} />
+          ))}
+        </div>
+      </section>
+
+      <TicketModal ticket={selectedTicket} onClose={() => setSelectedTicket(null)} />
+    </div>
+  );
+}

--- a/frontend/src/components/FilterPanel.css
+++ b/frontend/src/components/FilterPanel.css
@@ -1,0 +1,193 @@
+.filter-panel {
+  background: linear-gradient(135deg, var(--tsmc-navy), var(--tsmc-blue));
+  color: var(--tsmc-light);
+  padding: 2.5rem clamp(1.5rem, 4vw, 3.5rem);
+  border-radius: 28px;
+  box-shadow: 0 18px 45px rgba(16, 32, 54, 0.35);
+  display: grid;
+  gap: 2rem;
+}
+
+.filter-header h1 {
+  font-size: clamp(2rem, 3vw, 2.75rem);
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+}
+
+.filter-header p {
+  margin: 0;
+  font-size: 1rem;
+  opacity: 0.85;
+}
+
+.filter-section h2 {
+  font-size: 1rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 0.75rem;
+  color: var(--tsmc-light);
+}
+
+.field-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.75rem;
+}
+
+.field-option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.75rem 1rem;
+  border-radius: 16px;
+  background-color: rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(10px);
+  transition: transform 0.2s ease, background-color 0.2s ease;
+  cursor: pointer;
+}
+
+.field-option:hover {
+  transform: translateY(-1px);
+  background-color: rgba(255, 255, 255, 0.16);
+}
+
+.field-option input {
+  accent-color: var(--tsmc-red);
+  width: 18px;
+  height: 18px;
+}
+
+.field-option span {
+  font-weight: 600;
+}
+
+.field-inputs,
+.text-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1rem;
+}
+
+.input-group {
+  display: grid;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+}
+
+.input-group span {
+  font-weight: 600;
+}
+
+.input-group input,
+.input-group textarea {
+  padding: 0.75rem 1rem;
+  border-radius: 14px;
+  border: none;
+  background: rgba(255, 255, 255, 0.12);
+  color: var(--tsmc-light);
+  font-size: 0.95rem;
+  outline: 1px solid transparent;
+  transition: outline 0.2s ease, background 0.2s ease;
+}
+
+.input-group input::placeholder,
+.input-group textarea::placeholder {
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.input-group input:focus,
+.input-group textarea:focus {
+  outline: 2px solid var(--tsmc-red);
+  background: rgba(255, 255, 255, 0.18);
+}
+
+.input-group textarea {
+  min-height: 3.5rem;
+  resize: vertical;
+  line-height: 1.4;
+  overflow: auto;
+}
+
+.date-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.date-group {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.group-label {
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.date-inputs {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.date-inputs input {
+  padding: 0.65rem 0.9rem;
+  border-radius: 12px;
+  border: none;
+  background: rgba(255, 255, 255, 0.12);
+  color: var(--tsmc-light);
+  font-size: 0.9rem;
+  width: 100%;
+}
+
+.date-inputs input:focus {
+  outline: 2px solid var(--tsmc-red);
+  background: rgba(255, 255, 255, 0.18);
+}
+
+.date-inputs input::-webkit-calendar-picker-indicator {
+  filter: invert(1);
+}
+
+.delimiter {
+  font-size: 0.85rem;
+  opacity: 0.85;
+}
+
+.filter-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 0.5rem;
+}
+
+.filter-actions button {
+  background: var(--tsmc-red);
+  color: var(--tsmc-light);
+  border: none;
+  border-radius: 999px;
+  padding: 0.85rem 1.75rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  box-shadow: 0 18px 36px rgba(239, 51, 64, 0.35);
+}
+
+.filter-actions button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 24px 44px rgba(239, 51, 64, 0.45);
+}
+
+.filter-actions button:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+  box-shadow: none;
+}
+
+@media (max-width: 768px) {
+  .filter-panel {
+    padding: 1.75rem 1.25rem;
+  }
+}

--- a/frontend/src/components/FilterPanel.tsx
+++ b/frontend/src/components/FilterPanel.tsx
@@ -1,0 +1,169 @@
+import type { FilterField, FilterState } from "../types";
+import "./FilterPanel.css";
+
+const FILTER_FIELDS: { key: FilterField; label: string }[] = [
+  { key: "id", label: "Ticket ID" },
+  { key: "status", label: "狀態" },
+  { key: "vendor", label: "廠商" },
+  { key: "model", label: "型號" },
+  { key: "version", label: "版本" },
+  { key: "machine.serial", label: "機器序號" },
+  { key: "machine.ip", label: "機器 IP" },
+  { key: "machine.port", label: "機器 Port" }
+];
+
+interface FilterPanelProps {
+  filters: FilterState;
+  onChange: (filters: FilterState) => void;
+  onSubmit: () => void;
+  submitting?: boolean;
+}
+
+export function FilterPanel({ filters, onChange, onSubmit, submitting = false }: FilterPanelProps) {
+  const toggleField = (field: FilterField) => {
+    const isActive = filters.activeFields.includes(field);
+    const nextFields = isActive
+      ? filters.activeFields.filter((item) => item !== field)
+      : [...filters.activeFields, field];
+
+    const nextValues = { ...filters.fieldValues };
+    if (!isActive) {
+      nextValues[field] = nextValues[field] ?? "";
+    } else {
+      delete nextValues[field];
+    }
+
+    onChange({
+      ...filters,
+      activeFields: nextFields,
+      fieldValues: nextValues
+    });
+  };
+
+  const updateFieldValue = (field: FilterField, value: string) => {
+    onChange({
+      ...filters,
+      fieldValues: {
+        ...filters.fieldValues,
+        [field]: value
+      }
+    });
+  };
+
+  const updateDate = (field: "enqueued_at" | "started_at" | "completed_at", part: "from" | "to", value: string) => {
+    onChange({
+      ...filters,
+      dateRanges: {
+        ...filters.dateRanges,
+        [field]: {
+          ...filters.dateRanges[field],
+          [part]: value
+        }
+      }
+    });
+  };
+
+  return (
+    <section className="filter-panel">
+      <div className="filter-header">
+        <h1>Switch Ticket Explorer</h1>
+        <p>依照欄位與時間範圍快速篩選待處理與歷史 ticket。</p>
+      </div>
+
+      <div className="filter-section">
+        <h2>選擇欄位</h2>
+        <div className="field-grid">
+          {FILTER_FIELDS.map(({ key, label }) => (
+            <label key={key} className="field-option">
+              <input
+                type="checkbox"
+                checked={filters.activeFields.includes(key)}
+                onChange={() => toggleField(key)}
+              />
+              <span>{label}</span>
+            </label>
+          ))}
+        </div>
+      </div>
+
+      {filters.activeFields.length > 0 && (
+        <div className="filter-section">
+          <h2>欄位內容</h2>
+          <div className="field-inputs">
+            {filters.activeFields.map((field) => (
+              <label key={field} className="input-group">
+                <span>{FILTER_FIELDS.find((item) => item.key === field)?.label ?? field}</span>
+                <input
+                  type="text"
+                  value={filters.fieldValues[field] ?? ""}
+                  onChange={(event) => updateFieldValue(field, event.target.value)}
+                  placeholder="輸入關鍵字"
+                />
+              </label>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className="filter-section">
+        <h2>時間範圍</h2>
+        <div className="date-grid">
+          {(["enqueued_at", "started_at", "completed_at"] as const).map((field) => (
+            <div key={field} className="date-group">
+              <span className="group-label">
+                {field === "enqueued_at" && "排入佇列時間"}
+                {field === "started_at" && "開始時間"}
+                {field === "completed_at" && "完成時間"}
+              </span>
+              <div className="date-inputs">
+                <input
+                  type="datetime-local"
+                  value={filters.dateRanges[field].from ?? ""}
+                  onChange={(event) => updateDate(field, "from", event.target.value)}
+                />
+                <span className="delimiter">至</span>
+                <input
+                  type="datetime-local"
+                  value={filters.dateRanges[field].to ?? ""}
+                  onChange={(event) => updateDate(field, "to", event.target.value)}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="filter-section">
+        <h2>內容搜尋</h2>
+        <div className="text-grid">
+          <label className="input-group">
+            <span>Result Data</span>
+            <textarea
+              rows={3}
+              value={filters.resultData}
+              onChange={(event) => onChange({ ...filters, resultData: event.target.value })}
+              placeholder="輸入結果內容關鍵字"
+              spellCheck={false}
+            />
+          </label>
+          <label className="input-group">
+            <span>Switch Config (raw_data)</span>
+            <textarea
+              rows={3}
+              value={filters.rawData}
+              onChange={(event) => onChange({ ...filters, rawData: event.target.value })}
+              placeholder="輸入設定內容關鍵字"
+              spellCheck={false}
+            />
+          </label>
+        </div>
+      </div>
+
+      <div className="filter-actions">
+        <button type="button" onClick={onSubmit} disabled={submitting}>
+          {submitting ? "搜尋中..." : "送出查詢"}
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/TicketCard.css
+++ b/frontend/src/components/TicketCard.css
@@ -1,0 +1,105 @@
+.ticket-card {
+  background: var(--surface);
+  color: var(--ink);
+  border-radius: 24px;
+  padding: 1.75rem;
+  display: grid;
+  gap: 1.25rem;
+  cursor: pointer;
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+  box-shadow: 0 12px 30px rgba(18, 28, 43, 0.1);
+}
+
+.ticket-card:focus,
+.ticket-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 18px 36px rgba(18, 28, 43, 0.18);
+}
+
+.ticket-card__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.ticket-card__header h3 {
+  font-size: 1.05rem;
+  margin: 0;
+  word-break: break-all;
+  color: var(--ink-strong);
+}
+
+.status {
+  align-self: flex-start;
+  padding: 0.3rem 0.85rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  background: rgba(0, 0, 0, 0.08);
+  color: var(--ink-strong);
+}
+
+.status--completed {
+  background: rgba(46, 183, 152, 0.18);
+  color: #108a68;
+}
+
+.status--running {
+  background: rgba(255, 191, 71, 0.22);
+  color: #b76b00;
+}
+
+.status--failed {
+  background: rgba(239, 51, 64, 0.15);
+  color: var(--tsmc-red);
+}
+
+.ticket-card__grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  margin: 0;
+}
+
+.ticket-card__grid dt {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ink-muted);
+}
+
+.ticket-card__grid dd {
+  margin: 0.2rem 0 0;
+  font-weight: 600;
+  color: var(--ink-strong);
+}
+
+.machine {
+  border-top: 1px solid rgba(12, 26, 38, 0.08);
+  padding-top: 1rem;
+}
+
+.machine h4 {
+  margin: 0 0 0.75rem;
+  font-size: 0.9rem;
+  color: var(--ink-strong);
+}
+
+.machine__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.75rem;
+}
+
+.machine__grid .label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ink-muted);
+}
+
+.machine__grid span:last-child {
+  font-weight: 600;
+}

--- a/frontend/src/components/TicketCard.tsx
+++ b/frontend/src/components/TicketCard.tsx
@@ -1,0 +1,77 @@
+import type { KeyboardEvent } from "react";
+import type { Ticket } from "../types";
+import "./TicketCard.css";
+
+interface TicketCardProps {
+  ticket: Ticket;
+  onClick: (ticket: Ticket) => void;
+}
+
+export function TicketCard({ ticket, onClick }: TicketCardProps) {
+  const handleKeyDown = (event: KeyboardEvent<HTMLElement>) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      onClick(ticket);
+    }
+  };
+
+  return (
+    <article
+      className="ticket-card"
+      onClick={() => onClick(ticket)}
+      role="button"
+      tabIndex={0}
+      onKeyDown={handleKeyDown}
+    >
+      <header className="ticket-card__header">
+        <span className={`status status--${ticket.status}`}>{ticket.status}</span>
+        <h3>{ticket.id}</h3>
+      </header>
+      <dl className="ticket-card__grid">
+        <div>
+          <dt>廠商</dt>
+          <dd>{ticket.vendor}</dd>
+        </div>
+        <div>
+          <dt>型號</dt>
+          <dd>{ticket.model}</dd>
+        </div>
+        <div>
+          <dt>版本</dt>
+          <dd>{ticket.version}</dd>
+        </div>
+        <div>
+          <dt>排入佇列</dt>
+          <dd>{ticket.enqueued_at || "-"}</dd>
+        </div>
+        <div>
+          <dt>開始時間</dt>
+          <dd>{ticket.started_at || "-"}</dd>
+        </div>
+        <div>
+          <dt>完成時間</dt>
+          <dd>{ticket.completed_at || "-"}</dd>
+        </div>
+      </dl>
+      {ticket.machine && (
+        <section className="machine">
+          <h4>執行機器</h4>
+          <div className="machine__grid">
+            <div>
+              <span className="label">Serial</span>
+              <span>{ticket.machine.serial}</span>
+            </div>
+            <div>
+              <span className="label">IP</span>
+              <span>{ticket.machine.ip}</span>
+            </div>
+            <div>
+              <span className="label">Port</span>
+              <span>{ticket.machine.port}</span>
+            </div>
+          </div>
+        </section>
+      )}
+    </article>
+  );
+}

--- a/frontend/src/components/TicketModal.css
+++ b/frontend/src/components/TicketModal.css
@@ -1,0 +1,133 @@
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(8, 18, 32, 0.72);
+  display: grid;
+  place-items: center;
+  padding: 2rem clamp(1rem, 4vw, 3rem);
+  z-index: 1000;
+}
+
+.modal {
+  width: min(960px, 100%);
+  max-height: 90vh;
+  background: var(--surface);
+  border-radius: 24px;
+  box-shadow: 0 28px 60px rgba(12, 26, 38, 0.25);
+  overflow: hidden;
+  display: grid;
+  grid-template-rows: auto auto 1fr;
+}
+
+.modal__header {
+  padding: 1.75rem 2rem 1.5rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  background: linear-gradient(135deg, rgba(0, 90, 170, 0.12), rgba(239, 51, 64, 0.08));
+}
+
+.modal__header h3 {
+  margin: 0.35rem 0 0;
+  font-size: 1.1rem;
+  color: var(--ink-strong);
+  word-break: break-all;
+}
+
+.modal__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 600;
+  color: var(--tsmc-red);
+}
+
+.modal__close {
+  border: none;
+  background: rgba(0, 0, 0, 0.06);
+  width: 36px;
+  height: 36px;
+  border-radius: 12px;
+  font-size: 1.4rem;
+  line-height: 1;
+  cursor: pointer;
+  color: var(--ink);
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.modal__close:hover {
+  background: rgba(239, 51, 64, 0.16);
+  transform: rotate(90deg);
+}
+
+.modal__tabs {
+  display: grid;
+  grid-auto-flow: column;
+  background: var(--surface-muted);
+  gap: 0.35rem;
+  padding: 0.75rem;
+}
+
+.modal__tabs button {
+  border: none;
+  border-radius: 14px;
+  padding: 0.75rem 1.25rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: var(--ink-muted);
+  background: transparent;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.modal__tabs button.active {
+  background: linear-gradient(135deg, var(--tsmc-red), #ff745d);
+  color: #fff;
+}
+
+.modal__content {
+  padding: 1.5rem 2rem 2rem;
+  overflow: hidden;
+  background: var(--surface);
+  display: grid;
+}
+
+.modal__content pre {
+  white-space: pre-wrap;
+  word-break: break-word;
+  margin: 0;
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  background: var(--surface-muted);
+  padding: 1.5rem;
+  border-radius: 18px;
+  color: var(--ink-strong);
+  max-height: min(56vh, 480px);
+  overflow: auto;
+}
+
+.modal__content .empty {
+  margin: 0;
+  color: var(--ink-muted);
+  font-style: italic;
+  text-align: center;
+}
+
+@media (max-width: 640px) {
+  .modal {
+    border-radius: 18px;
+  }
+
+  .modal__header,
+  .modal__content {
+    padding: 1.25rem 1.5rem;
+  }
+
+  .modal__tabs {
+    grid-auto-flow: row;
+  }
+}

--- a/frontend/src/components/TicketModal.tsx
+++ b/frontend/src/components/TicketModal.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useState } from "react";
+import type { Ticket } from "../types";
+import "./TicketModal.css";
+
+interface TicketModalProps {
+  ticket: Ticket | null;
+  onClose: () => void;
+}
+
+type TabKey = "result" | "raw";
+
+const TAB_LABELS: Record<TabKey, string> = {
+  result: "Result Data",
+  raw: "Switch Config"
+};
+
+export function TicketModal({ ticket, onClose }: TicketModalProps) {
+  const [activeTab, setActiveTab] = useState<TabKey>("result");
+
+  useEffect(() => {
+    setActiveTab("result");
+  }, [ticket?.id]);
+
+  useEffect(() => {
+    const listener = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", listener);
+    return () => window.removeEventListener("keydown", listener);
+  }, [onClose]);
+
+  if (!ticket) {
+    return null;
+  }
+
+  const content = activeTab === "result" ? ticket.result_data : ticket.raw_data;
+
+  return (
+    <div className="modal-backdrop" onClick={onClose}>
+      <div className="modal" role="dialog" aria-modal="true" onClick={(event) => event.stopPropagation()}>
+        <header className="modal__header">
+          <div>
+            <span className="modal__status">{ticket.status}</span>
+            <h3>{ticket.id}</h3>
+          </div>
+          <button type="button" className="modal__close" onClick={onClose}>
+            ×
+          </button>
+        </header>
+        <nav className="modal__tabs">
+          {(Object.keys(TAB_LABELS) as TabKey[]).map((key) => (
+            <button
+              key={key}
+              type="button"
+              className={key === activeTab ? "active" : ""}
+              onClick={() => setActiveTab(key)}
+            >
+              {TAB_LABELS[key]}
+            </button>
+          ))}
+        </nav>
+        <section className="modal__content">
+          {content ? (
+            <pre>{content}</pre>
+          ) : (
+            <p className="empty">無內容</p>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useTickets.ts
+++ b/frontend/src/hooks/useTickets.ts
@@ -1,0 +1,112 @@
+import { useEffect, useState } from "react";
+import type { FilterState, Ticket } from "../types";
+
+const API_PATH = "/tickets/search";
+const DEFAULT_BASE_URL = "http://localhost:8000";
+
+function sanitizeFieldValues(filters: FilterState): Partial<Record<string, string>> {
+  const values: Partial<Record<string, string>> = {};
+
+  filters.activeFields.forEach((field) => {
+    const rawValue = filters.fieldValues[field];
+    const trimmed = rawValue?.trim();
+    if (trimmed) {
+      values[field] = trimmed;
+    }
+  });
+
+  return values;
+}
+
+function sanitizeDateRanges(filters: FilterState): Record<string, { from?: string; to?: string }> {
+  const ranges: Record<string, { from?: string; to?: string }> = {};
+
+  (Object.entries(filters.dateRanges) as [string, { from?: string; to?: string }][]).forEach(
+    ([key, range]) => {
+      const from = range.from?.trim();
+      const to = range.to?.trim();
+
+      if (from || to) {
+        ranges[key] = {
+          ...(from ? { from } : {}),
+          ...(to ? { to } : {}),
+        };
+      }
+    }
+  );
+
+  return ranges;
+}
+
+function buildPayload(filters: FilterState) {
+  return {
+    activeFields: filters.activeFields,
+    fieldValues: sanitizeFieldValues(filters),
+    dateRanges: sanitizeDateRanges(filters),
+    resultData: filters.resultData.trim(),
+    rawData: filters.rawData.trim(),
+  };
+}
+
+async function requestTickets(filters: FilterState): Promise<Ticket[]> {
+  const baseUrl = import.meta.env.VITE_API_BASE_URL ?? DEFAULT_BASE_URL;
+
+  try {
+    const response = await fetch(`${baseUrl}${API_PATH}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(buildPayload(filters))
+    });
+
+    if (!response.ok) {
+      throw new Error(`Request failed with status ${response.status}`);
+    }
+
+    const data = (await response.json()) as { tickets?: Ticket[] } | Ticket[];
+    if (Array.isArray(data)) {
+      return data;
+    }
+    return data.tickets ?? [];
+  } catch (error) {
+    throw error;
+  }
+}
+
+export function useTickets(filters: FilterState) {
+  const [tickets, setTickets] = useState<Ticket[]>([]);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+    setLoading(true);
+    setError(null);
+
+    requestTickets(filters)
+      .then((data) => {
+        if (!isMounted) {
+          return;
+        }
+        setTickets(data);
+      })
+      .catch((err: unknown) => {
+        if (!isMounted) {
+          return;
+        }
+        console.error(err);
+        setError("無法從伺服器取得資料，請稍後再試。");
+        setTickets([]);
+      })
+      .finally(() => {
+        if (isMounted) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [filters]);
+
+  return { tickets, loading, error };
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,34 @@
+:root {
+  font-family: "Inter", "Noto Sans TC", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+  color-scheme: light dark;
+  line-height: 1.6;
+  --tsmc-red: #ef3340;
+  --tsmc-blue: #005daa;
+  --tsmc-navy: #0c1a2e;
+  --tsmc-light: #f5f6fa;
+  --surface: #ffffff;
+  --surface-muted: #f1f4f9;
+  --ink: #233047;
+  --ink-strong: #161f2f;
+  --ink-muted: #5c667a;
+  background-color: #070c1a;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background-color: #070c1a;
+}
+
+a {
+  color: inherit;
+}
+
+button {
+  font-family: inherit;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import "./index.css";
+
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,0 +1,47 @@
+export type TicketStatus = "queued" | "running" | "completed" | "failed";
+
+export interface MachineInfo {
+  serial: string;
+  ip: string;
+  port: number;
+}
+
+export interface Ticket {
+  id: string;
+  status: TicketStatus;
+  vendor: string;
+  model: string;
+  version: string;
+  enqueued_at: string;
+  started_at: string | null;
+  completed_at: string | null;
+  machine: MachineInfo | null;
+  result_data?: string | null;
+  raw_data?: string | null;
+  message?: string;
+}
+
+export type FilterField =
+  | "id"
+  | "status"
+  | "vendor"
+  | "model"
+  | "version"
+  | "machine.serial"
+  | "machine.ip"
+  | "machine.port";
+
+export type DateField = "enqueued_at" | "started_at" | "completed_at";
+
+export interface DateRange {
+  from?: string;
+  to?: string;
+}
+
+export interface FilterState {
+  activeFields: FilterField[];
+  fieldValues: Partial<Record<FilterField, string>>;
+  dateRanges: Record<DateField, DateRange>;
+  resultData: string;
+  rawData: string;
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "references": [
+    {
+      "path": "./tsconfig.node.json"
+    }
+  ]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    host: "0.0.0.0"
+  }
+});


### PR DESCRIPTION
## Summary
- refactor the ticket search endpoint to validate incoming fields against the Ticket model and reuse machine metadata during filtering
- switch the result and raw query inputs to multiline areas and tighten the date range layout so the controls stay within the filter panel
- cap the ticket detail modal height and make tab content scrollable for lengthy result data or switch configs

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68d83842b2ac833397e6d41702810e26