### PR TITLE
Revamp search interface with TSMC-themed filter menu

### DIFF
--- a/app/api/devices.py
+++ b/app/api/devices.py
@@ -1,0 +1,12 @@
+from fastapi import APIRouter
+
+from app.utils import load_device
+
+router = APIRouter()
+
+
+@router.get("/options")
+def get_device_options() -> dict:
+    """Return the structured device configuration for filter selections."""
+    config = load_device()
+    return config

--- a/app/main.py
+++ b/app/main.py
@@ -7,6 +7,7 @@ from app.api.request import router as request_router
 from app.api.reset import router as reset_router
 from app.api.result import router as result_router
 from app.api.search import router as tickets_router
+from app.api.devices import router as devices_router
 from app.logging_config import setup_logging
 from app.services.ticket_manager import TicketManager
 
@@ -29,6 +30,7 @@ app.include_router(request_router, prefix="/request", tags=["request"])
 app.include_router(result_router, prefix="/result", tags=["result"])
 app.include_router(reset_router, prefix="/reset", tags=["reset"])
 app.include_router(tickets_router, prefix="/tickets", tags=["tickets"])
+app.include_router(devices_router, prefix="/devices", tags=["devices"])
 
 
 @app.get("/health", tags=["health"])

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,20 +1,114 @@
-.layout {
+.app-shell {
   min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: linear-gradient(180deg, #f7f8fb 0%, #e6eaef 40%, #dfe3ea 100%);
+  color: #1e2a3a;
+}
+
+.top-bar {
   display: grid;
-  gap: 2.5rem;
-  padding: clamp(1.5rem, 4vw, 3rem);
-  background: radial-gradient(circle at top left, rgba(239, 51, 64, 0.12), transparent 45%),
-    radial-gradient(circle at 80% 20%, rgba(0, 102, 204, 0.18), transparent 50%),
-    linear-gradient(180deg, #0f172a, #090b1a 55%, #0c172c 100%);
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 1.5rem;
+  padding: 1.5rem clamp(1.5rem, 4vw, 3rem);
+  background: linear-gradient(90deg, #1a1c2d 0%, #2a2f44 35%, #5b677f 100%);
+  color: #f7f8fb;
+  box-shadow: 0 18px 36px rgba(23, 32, 48, 0.35);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.menu-button {
+  display: inline-flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 0.3rem;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  background: rgba(230, 0, 18, 0.85);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.menu-button span {
+  display: block;
+  height: 3px;
+  background: #f7f8fb;
+  border-radius: 999px;
+  margin: 0 0.75rem;
+}
+
+.menu-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 20px rgba(230, 0, 18, 0.4);
+}
+
+.brand h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 2.4vw, 2.2rem);
+  letter-spacing: 0.05em;
+}
+
+.brand p {
+  margin: 0.25rem 0 0;
+  color: rgba(247, 248, 251, 0.75);
+}
+
+.filter-status {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  background: rgba(255, 255, 255, 0.1);
+  padding: 0.75rem 1.2rem;
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.status-label {
+  font-size: 0.85rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: rgba(247, 248, 251, 0.75);
+}
+
+.status-count {
+  min-width: 2.1rem;
+  height: 2.1rem;
+  display: grid;
+  place-items: center;
+  background: #f7f8fb;
+  color: #1a1c2d;
+  font-weight: 700;
+  border-radius: 999px;
+}
+
+.filter-status button {
+  border: 0;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #ff4f5a, #e60012);
+  color: #fff;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  padding: 0.6rem 1.6rem;
+  cursor: pointer;
+  box-shadow: 0 12px 26px rgba(230, 0, 18, 0.4);
+}
+
+.filter-status button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
 }
 
 .results {
-  background: rgba(255, 255, 255, 0.94);
-  border-radius: 32px;
-  padding: clamp(1.75rem, 3vw, 2.5rem);
-  box-shadow: 0 30px 60px rgba(6, 11, 22, 0.28);
+  flex: 1;
   display: grid;
   gap: 1.75rem;
+  padding: clamp(2rem, 4vw, 3rem);
 }
 
 .results__header {
@@ -26,14 +120,14 @@
 }
 
 .results__header h2 {
-  margin: 0 0 0.25rem;
-  font-size: clamp(1.4rem, 2vw, 1.8rem);
-  color: var(--ink-strong);
+  margin: 0;
+  font-size: clamp(1.5rem, 2vw, 2rem);
+  color: #1a1c2d;
 }
 
 .results__header p {
   margin: 0;
-  color: var(--ink-muted);
+  color: #4a5261;
 }
 
 .card-grid {
@@ -45,8 +139,8 @@
 .alert {
   padding: 1rem 1.25rem;
   border-radius: 16px;
-  background: rgba(239, 51, 64, 0.1);
-  color: var(--tsmc-red);
+  background: rgba(230, 0, 18, 0.08);
+  color: #e60012;
   font-weight: 600;
 }
 
@@ -55,21 +149,30 @@
   align-items: center;
   padding: 0.4rem 1rem;
   border-radius: 999px;
-  background: rgba(0, 102, 204, 0.14);
-  color: var(--tsmc-blue);
+  background: rgba(26, 28, 45, 0.1);
+  color: #1a1c2d;
   font-weight: 600;
   letter-spacing: 0.04em;
 }
 
 .empty {
   margin: 0;
-  color: var(--ink-muted);
+  color: #4a5261;
   font-style: italic;
 }
 
-@media (min-width: 1280px) {
-  .layout {
-    grid-template-columns: 420px 1fr;
-    align-items: start;
+@media (max-width: 768px) {
+  .top-bar {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+    text-align: center;
+  }
+
+  .menu-button {
+    justify-self: center;
+  }
+
+  .filter-status {
+    justify-content: center;
   }
 }

--- a/frontend/src/components/FilterPanel.css
+++ b/frontend/src/components/FilterPanel.css
@@ -1,193 +1,300 @@
-.filter-panel {
-  background: linear-gradient(135deg, var(--tsmc-navy), var(--tsmc-blue));
-  color: var(--tsmc-light);
-  padding: 2.5rem clamp(1.5rem, 4vw, 3.5rem);
+.filter-menu {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  z-index: 20;
+}
+
+.filter-menu__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(17, 21, 34, 0.65);
+  backdrop-filter: blur(4px);
+}
+
+.filter-menu__container {
+  position: relative;
+  width: min(900px, 96vw);
+  max-height: 92vh;
+  background: linear-gradient(160deg, #1c1f2e, #0f1324 55%, #1f2231 100%);
   border-radius: 28px;
-  box-shadow: 0 18px 45px rgba(16, 32, 54, 0.35);
-  display: grid;
-  gap: 2rem;
+  padding: 2.5rem clamp(1.5rem, 3vw, 3rem);
+  color: #f6f7fb;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 40px 80px rgba(12, 18, 36, 0.55);
+  overflow: hidden;
 }
 
-.filter-header h1 {
-  font-size: clamp(2rem, 3vw, 2.75rem);
-  font-weight: 700;
-  margin-bottom: 0.5rem;
+.filter-menu__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.5rem;
+  margin-bottom: 1.5rem;
 }
 
-.filter-header p {
+.filter-menu__header h1 {
   margin: 0;
-  font-size: 1rem;
-  opacity: 0.85;
+  font-size: clamp(1.8rem, 2.8vw, 2.4rem);
+  letter-spacing: 0.04em;
 }
 
-.filter-section h2 {
-  font-size: 1rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  margin-bottom: 0.75rem;
-  color: var(--tsmc-light);
+.filter-menu__header p {
+  margin: 0.2rem 0 0;
+  color: rgba(246, 247, 251, 0.7);
 }
 
-.field-grid {
+.icon-button {
+  background: transparent;
+  border: 0;
+  color: inherit;
+  font-size: 2rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0;
+}
+
+.filter-menu__content {
+  flex: 1;
+  overflow-y: auto;
+  padding-right: 0.75rem;
+  margin-right: -0.75rem;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  gap: 0.75rem;
+  gap: 1rem;
 }
 
-.field-option {
-  display: inline-flex;
+.filter-section {
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 20px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.section-toggle {
+  width: 100%;
+  background: linear-gradient(90deg, rgba(230, 0, 18, 0.85), rgba(230, 0, 18, 0.6));
+  border: 0;
+  display: flex;
   align-items: center;
-  gap: 0.6rem;
-  padding: 0.75rem 1rem;
-  border-radius: 16px;
-  background-color: rgba(255, 255, 255, 0.08);
-  backdrop-filter: blur(10px);
-  transition: transform 0.2s ease, background-color 0.2s ease;
+  justify-content: space-between;
+  padding: 1rem 1.25rem;
+  color: #fff;
+  font-size: 1.05rem;
+  font-weight: 600;
   cursor: pointer;
 }
 
-.field-option:hover {
-  transform: translateY(-1px);
-  background-color: rgba(255, 255, 255, 0.16);
+.section-toggle.open {
+  background: linear-gradient(90deg, rgba(230, 0, 18, 1), rgba(200, 0, 24, 0.8));
 }
 
-.field-option input {
-  accent-color: var(--tsmc-red);
+.section-toggle__icon {
+  width: 0;
+  height: 0;
+  border-left: 8px solid transparent;
+  border-right: 8px solid transparent;
+  border-top: 12px solid #000;
+  transition: transform 0.25s ease;
+}
+
+.section-toggle.open .section-toggle__icon {
+  transform: rotate(180deg);
+}
+
+.section-panel {
+  padding: 1.25rem 1.5rem 1.5rem;
+  background: rgba(6, 8, 14, 0.35);
+}
+
+.filter-section__body {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.option-group {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.option-group__title {
+  margin: 0;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+}
+
+.option-hint {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(246, 247, 251, 0.6);
+}
+
+.option-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.option-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.65rem 1rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.option-chip:hover {
+  transform: translateY(-1px);
+  background: rgba(255, 255, 255, 0.16);
+}
+
+.option-chip input {
+  accent-color: #e60012;
   width: 18px;
   height: 18px;
 }
 
-.field-option span {
-  font-weight: 600;
-}
-
-.field-inputs,
-.text-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: 1rem;
-}
-
-.input-group {
-  display: grid;
-  gap: 0.5rem;
-  font-size: 0.95rem;
-}
-
-.input-group span {
-  font-weight: 600;
-}
-
-.input-group input,
-.input-group textarea {
-  padding: 0.75rem 1rem;
-  border-radius: 14px;
-  border: none;
-  background: rgba(255, 255, 255, 0.12);
-  color: var(--tsmc-light);
-  font-size: 0.95rem;
-  outline: 1px solid transparent;
-  transition: outline 0.2s ease, background 0.2s ease;
-}
-
-.input-group input::placeholder,
-.input-group textarea::placeholder {
-  color: rgba(255, 255, 255, 0.6);
-}
-
-.input-group input:focus,
-.input-group textarea:focus {
-  outline: 2px solid var(--tsmc-red);
-  background: rgba(255, 255, 255, 0.18);
-}
-
-.input-group textarea {
-  min-height: 3.5rem;
-  resize: vertical;
-  line-height: 1.4;
-  overflow: auto;
-}
-
-.date-grid {
+.device-detail-grid {
   display: grid;
   gap: 1rem;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
-.date-group {
+.device-detail-column {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.device-detail-column h4 {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+.input-row {
   display: grid;
   gap: 0.5rem;
 }
 
-.group-label {
+.input-row span {
   font-weight: 600;
-  letter-spacing: 0.04em;
+}
+
+.input-row input {
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(8, 12, 20, 0.6);
+  color: #f6f7fb;
+  padding: 0.75rem 1rem;
+  font-size: 0.95rem;
+}
+
+.input-row input::placeholder {
+  color: rgba(246, 247, 251, 0.5);
+}
+
+.date-body {
+  gap: 1.25rem;
+}
+
+.date-row {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.date-label {
+  font-weight: 600;
 }
 
 .date-inputs {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
-  gap: 0.5rem;
   align-items: center;
+  gap: 0.5rem;
 }
 
 .date-inputs input {
-  padding: 0.65rem 0.9rem;
   border-radius: 12px;
-  border: none;
-  background: rgba(255, 255, 255, 0.12);
-  color: var(--tsmc-light);
-  font-size: 0.9rem;
-  width: 100%;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  padding: 0.65rem 0.9rem;
+  background: rgba(8, 12, 20, 0.6);
+  color: #f6f7fb;
 }
 
 .date-inputs input:focus {
-  outline: 2px solid var(--tsmc-red);
-  background: rgba(255, 255, 255, 0.18);
-}
-
-.date-inputs input::-webkit-calendar-picker-indicator {
-  filter: invert(1);
+  outline: 2px solid #e60012;
 }
 
 .delimiter {
   font-size: 0.85rem;
-  opacity: 0.85;
+  color: rgba(246, 247, 251, 0.7);
 }
 
-.filter-actions {
+.error-text {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #ff9f7a;
+}
+
+.advanced-body {
+  gap: 0.75rem;
+}
+
+.advanced-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.advanced-actions button {
+  border: 0;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #ff4f5a, #e60012);
+  color: #fff;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  padding: 0.75rem 1.5rem;
+  cursor: pointer;
+  box-shadow: 0 14px 30px rgba(230, 0, 18, 0.35);
+}
+
+.filter-menu__footer {
   display: flex;
   justify-content: flex-end;
-  margin-top: 0.5rem;
+  padding-top: 1.5rem;
 }
 
-.filter-actions button {
-  background: var(--tsmc-red);
-  color: var(--tsmc-light);
-  border: none;
+.filter-menu__footer button {
+  border: 0;
   border-radius: 999px;
-  padding: 0.85rem 1.75rem;
+  padding: 0.85rem 2.4rem;
+  background: linear-gradient(135deg, #ff4f5a, #e60012);
+  color: #fff;
   font-weight: 700;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
   cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
-  box-shadow: 0 18px 36px rgba(239, 51, 64, 0.35);
+  box-shadow: 0 22px 40px rgba(230, 0, 18, 0.45);
 }
 
-.filter-actions button:hover:not(:disabled) {
-  transform: translateY(-1px);
-  box-shadow: 0 24px 44px rgba(239, 51, 64, 0.45);
-}
-
-.filter-actions button:disabled {
-  cursor: not-allowed;
+.filter-menu__footer button:disabled {
   opacity: 0.65;
+  cursor: not-allowed;
   box-shadow: none;
 }
 
 @media (max-width: 768px) {
-  .filter-panel {
-    padding: 1.75rem 1.25rem;
+  .filter-menu__container {
+    padding: 2rem 1.25rem;
+  }
+
+  .filter-menu__content {
+    padding-right: 0.25rem;
+    margin-right: -0.25rem;
   }
 }

--- a/frontend/src/components/FilterPanel.tsx
+++ b/frontend/src/components/FilterPanel.tsx
@@ -1,15 +1,20 @@
-import type { FilterField, FilterState } from "../types";
+import { useMemo, useState } from "react";
+import type { DeviceConfig, FilterField, FilterState } from "../types";
+import { TextEntryModal } from "./TextEntryModal";
 import "./FilterPanel.css";
 
-const FILTER_FIELDS: { key: FilterField; label: string }[] = [
-  { key: "id", label: "Ticket ID" },
-  { key: "status", label: "狀態" },
-  { key: "vendor", label: "廠商" },
-  { key: "model", label: "型號" },
-  { key: "version", label: "版本" },
-  { key: "machine.serial", label: "機器序號" },
-  { key: "machine.ip", label: "機器 IP" },
-  { key: "machine.port", label: "機器 Port" }
+const TEXT_FIELDS: { key: FilterField; label: string; placeholder: string }[] = [
+  { key: "id", label: "Ticket ID", placeholder: "輸入 ticket ID" },
+  { key: "status", label: "狀態", placeholder: "輸入狀態 (例如 queued)" },
+];
+
+const DEVICE_FIELDS: FilterField[] = [
+  "vendor",
+  "model",
+  "version",
+  "machine.ip",
+  "machine.serial",
+  "machine.port",
 ];
 
 interface FilterPanelProps {
@@ -17,153 +22,700 @@ interface FilterPanelProps {
   onChange: (filters: FilterState) => void;
   onSubmit: () => void;
   submitting?: boolean;
+  isOpen: boolean;
+  onClose: () => void;
+  deviceConfig: DeviceConfig | null;
+  deviceLoading: boolean;
+  deviceError: string | null;
 }
 
-export function FilterPanel({ filters, onChange, onSubmit, submitting = false }: FilterPanelProps) {
-  const toggleField = (field: FilterField) => {
-    const isActive = filters.activeFields.includes(field);
-    const nextFields = isActive
-      ? filters.activeFields.filter((item) => item !== field)
-      : [...filters.activeFields, field];
+type SectionId = "device" | "fields" | "dates" | "advanced";
 
+type DeviceSelections = {
+  vendor: string[];
+  model: string[];
+  version: string[];
+  "machine.ip": string[];
+  "machine.serial": string[];
+  "machine.port": string[];
+};
+
+function parseSelections(value: string | undefined): string[] {
+  if (!value) {
+    return [];
+  }
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+}
+
+function selectionToValue(values: string[]): string | undefined {
+  if (values.length === 0) {
+    return undefined;
+  }
+  return values.join(",");
+}
+
+function collectModelOptions(
+  config: DeviceConfig | null,
+  vendors: string[]
+): { vendor: string; name: string }[] {
+  if (!config || vendors.length === 0) {
+    return [];
+  }
+  const results: { vendor: string; name: string }[] = [];
+  config.vendors.forEach((vendorEntry) => {
+    if (!vendors.includes(vendorEntry.vendor)) {
+      return;
+    }
+    vendorEntry.models.forEach((model) => {
+      results.push({ vendor: vendorEntry.vendor, name: model.model });
+    });
+  });
+  return results;
+}
+
+function collectVersionOptions(
+  config: DeviceConfig | null,
+  vendors: string[],
+  models: string[]
+): { vendor: string; model: string; name: string }[] {
+  if (!config || vendors.length === 0 || models.length === 0) {
+    return [];
+  }
+  const results: { vendor: string; model: string; name: string }[] = [];
+  config.vendors.forEach((vendorEntry) => {
+    if (!vendors.includes(vendorEntry.vendor)) {
+      return;
+    }
+    vendorEntry.models.forEach((modelEntry) => {
+      if (!models.includes(modelEntry.model)) {
+        return;
+      }
+      modelEntry.versions.forEach((versionEntry) => {
+        results.push({
+          vendor: vendorEntry.vendor,
+          model: modelEntry.model,
+          name: versionEntry.version,
+        });
+      });
+    });
+  });
+  return results;
+}
+
+interface DeviceDetailOption {
+  vendor: string;
+  model: string;
+  version: string;
+  ip: string;
+  serial: string;
+  port: number;
+}
+
+function collectDeviceDetailOptions(
+  config: DeviceConfig | null,
+  vendors: string[],
+  models: string[],
+  versions: string[]
+): DeviceDetailOption[] {
+  if (!config || vendors.length === 0 || models.length === 0 || versions.length === 0) {
+    return [];
+  }
+  const results: DeviceDetailOption[] = [];
+  config.vendors.forEach((vendorEntry) => {
+    if (!vendors.includes(vendorEntry.vendor)) {
+      return;
+    }
+    vendorEntry.models.forEach((modelEntry) => {
+      if (!models.includes(modelEntry.model)) {
+        return;
+      }
+      modelEntry.versions.forEach((versionEntry) => {
+        if (!versions.includes(versionEntry.version)) {
+          return;
+        }
+        versionEntry.devices.forEach((device) => {
+          results.push({
+            vendor: vendorEntry.vendor,
+            model: modelEntry.model,
+            version: versionEntry.version,
+            ip: device.ip,
+            serial: device.serial_number,
+            port: device.port,
+          });
+        });
+      });
+    });
+  });
+  return results;
+}
+
+function applyDeviceSelections(
+  filters: FilterState,
+  onChange: (filters: FilterState) => void,
+  selections: DeviceSelections
+) {
+  const nextFieldValues: FilterState["fieldValues"] = { ...filters.fieldValues };
+  let nextActiveFields = filters.activeFields.filter((field) => !DEVICE_FIELDS.includes(field));
+
+  DEVICE_FIELDS.forEach((field) => {
+    const values = selections[field];
+    const value = selectionToValue(values);
+    if (value) {
+      nextFieldValues[field] = value;
+      if (!nextActiveFields.includes(field)) {
+        nextActiveFields = [...nextActiveFields, field];
+      }
+    } else {
+      delete nextFieldValues[field];
+    }
+  });
+
+  onChange({
+    ...filters,
+    activeFields: nextActiveFields,
+    fieldValues: nextFieldValues,
+  });
+}
+
+function sanitizeSelections(
+  selections: DeviceSelections,
+  available: Partial<DeviceSelections>
+): DeviceSelections {
+  return {
+    vendor: selections.vendor.filter((item) => available.vendor?.includes(item) ?? true),
+    model: selections.model.filter((item) => available.model?.includes(item) ?? true),
+    version: selections.version.filter((item) => available.version?.includes(item) ?? true),
+    "machine.ip": selections["machine.ip"].filter((item) =>
+      available["machine.ip"]?.includes(item) ?? true
+    ),
+    "machine.serial": selections["machine.serial"].filter((item) =>
+      available["machine.serial"]?.includes(item) ?? true
+    ),
+    "machine.port": selections["machine.port"].filter((item) =>
+      available["machine.port"]?.includes(item) ?? true
+    ),
+  };
+}
+
+export function FilterPanel({
+  filters,
+  onChange,
+  onSubmit,
+  submitting = false,
+  isOpen,
+  onClose,
+  deviceConfig,
+  deviceLoading,
+  deviceError,
+}: FilterPanelProps) {
+  const [openSections, setOpenSections] = useState<SectionId[]>(["device"]);
+  const [activeTextModal, setActiveTextModal] = useState<"result" | "raw" | null>(null);
+  const [dateErrors, setDateErrors] = useState<Record<string, string>>({});
+
+  const selections: DeviceSelections = useMemo(
+    () => ({
+      vendor: parseSelections(filters.fieldValues.vendor),
+      model: parseSelections(filters.fieldValues.model),
+      version: parseSelections(filters.fieldValues.version),
+      "machine.ip": parseSelections(filters.fieldValues["machine.ip"]),
+      "machine.serial": parseSelections(filters.fieldValues["machine.serial"]),
+      "machine.port": parseSelections(filters.fieldValues["machine.port"]),
+    }),
+    [filters.fieldValues]
+  );
+
+  const vendorOptions = useMemo(() => deviceConfig?.vendors ?? [], [deviceConfig]);
+  const availableVendors = useMemo(
+    () => vendorOptions.map((vendor) => vendor.vendor),
+    [vendorOptions]
+  );
+  const modelOptions = useMemo(
+    () => collectModelOptions(deviceConfig, selections.vendor),
+    [deviceConfig, selections.vendor]
+  );
+  const availableModels = useMemo(
+    () => modelOptions.map((model) => model.name),
+    [modelOptions]
+  );
+  const versionOptions = useMemo(
+    () => collectVersionOptions(deviceConfig, selections.vendor, selections.model),
+    [deviceConfig, selections.vendor, selections.model]
+  );
+  const availableVersions = useMemo(
+    () => versionOptions.map((version) => version.name),
+    [versionOptions]
+  );
+  const deviceDetails = useMemo(
+    () => collectDeviceDetailOptions(deviceConfig, selections.vendor, selections.model, selections.version),
+    [deviceConfig, selections.vendor, selections.model, selections.version]
+  );
+  const availableIps = useMemo(
+    () => deviceDetails.map((device) => device.ip),
+    [deviceDetails]
+  );
+  const availableSerials = useMemo(
+    () => deviceDetails.map((device) => device.serial),
+    [deviceDetails]
+  );
+  const availablePorts = useMemo(
+    () => deviceDetails.map((device) => String(device.port)),
+    [deviceDetails]
+  );
+
+  const updateSelections = (next: DeviceSelections) => {
+    const sanitized = sanitizeSelections(next, {
+      vendor: availableVendors,
+      model: availableModels,
+      version: availableVersions,
+      "machine.ip": availableIps,
+      "machine.serial": availableSerials,
+      "machine.port": availablePorts,
+    });
+    applyDeviceSelections(filters, onChange, sanitized);
+  };
+
+  const toggleSection = (section: SectionId) => {
+    setOpenSections((prev) =>
+      prev.includes(section) ? prev.filter((item) => item !== section) : [...prev, section]
+    );
+  };
+
+  const updateDate = (
+    field: "enqueued_at" | "started_at" | "completed_at",
+    part: "from" | "to",
+    value: string
+  ) => {
+    const nextRanges = {
+      ...filters.dateRanges,
+      [field]: {
+        ...filters.dateRanges[field],
+        [part]: value,
+      },
+    } as FilterState["dateRanges"];
+
+    const from = nextRanges[field].from;
+    const to = nextRanges[field].to;
+    const hasError = Boolean(from && to && new Date(to) < new Date(from));
+    setDateErrors((prev) => ({
+      ...prev,
+      [field]: hasError ? "結束時間需晚於開始時間" : "",
+    }));
+
+    onChange({
+      ...filters,
+      dateRanges: nextRanges,
+    });
+  };
+
+  const updateTextField = (field: FilterField, value: string) => {
+    const trimmed = value.trim();
     const nextValues = { ...filters.fieldValues };
-    if (!isActive) {
-      nextValues[field] = nextValues[field] ?? "";
+    let nextActive = filters.activeFields;
+
+    if (trimmed.length > 0) {
+      nextValues[field] = trimmed;
+      if (!nextActive.includes(field)) {
+        nextActive = [...nextActive, field];
+      }
     } else {
       delete nextValues[field];
+      nextActive = nextActive.filter((item) => item !== field);
     }
 
     onChange({
       ...filters,
-      activeFields: nextFields,
-      fieldValues: nextValues
+      activeFields: nextActive,
+      fieldValues: nextValues,
     });
   };
 
-  const updateFieldValue = (field: FilterField, value: string) => {
-    onChange({
-      ...filters,
-      fieldValues: {
-        ...filters.fieldValues,
-        [field]: value
-      }
+  const toggleDeviceValue = (field: FilterField, value: string) => {
+    const currentValues = selections[field].slice();
+    const exists = currentValues.includes(value);
+    const nextValues = exists
+      ? currentValues.filter((item) => item !== value)
+      : [...currentValues, value];
+
+    updateSelections({
+      ...selections,
+      [field]: nextValues,
     });
   };
 
-  const updateDate = (field: "enqueued_at" | "started_at" | "completed_at", part: "from" | "to", value: string) => {
-    onChange({
-      ...filters,
-      dateRanges: {
-        ...filters.dateRanges,
-        [field]: {
-          ...filters.dateRanges[field],
-          [part]: value
-        }
-      }
+  const handleVendorToggle = (vendor: string) => {
+    const nextVendors = selections.vendor.includes(vendor)
+      ? selections.vendor.filter((item) => item !== vendor)
+      : [...selections.vendor, vendor];
+
+    const modelsAfterVendor = collectModelOptions(deviceConfig, nextVendors).map((model) => model.name);
+    const sanitizedModels = selections.model.filter((model) => modelsAfterVendor.includes(model));
+    const versionsAfterVendor = collectVersionOptions(deviceConfig, nextVendors, sanitizedModels).map(
+      (version) => version.name
+    );
+    const sanitizedVersions = selections.version.filter((version) => versionsAfterVendor.includes(version));
+    const devicesAfterVendor = collectDeviceDetailOptions(
+      deviceConfig,
+      nextVendors,
+      sanitizedModels,
+      sanitizedVersions
+    );
+
+    updateSelections({
+      vendor: nextVendors,
+      model: sanitizedModels,
+      version: sanitizedVersions,
+      "machine.ip": selections["machine.ip"].filter((ip) => devicesAfterVendor.some((d) => d.ip === ip)),
+      "machine.serial": selections["machine.serial"].filter((serial) =>
+        devicesAfterVendor.some((d) => d.serial === serial)
+      ),
+      "machine.port": selections["machine.port"].filter((port) =>
+        devicesAfterVendor.some((d) => String(d.port) === port)
+      ),
     });
   };
 
-  return (
-    <section className="filter-panel">
-      <div className="filter-header">
-        <h1>Switch Ticket Explorer</h1>
-        <p>依照欄位與時間範圍快速篩選待處理與歷史 ticket。</p>
-      </div>
+  const handleModelToggle = (model: string) => {
+    const nextModels = selections.model.includes(model)
+      ? selections.model.filter((item) => item !== model)
+      : [...selections.model, model];
 
-      <div className="filter-section">
-        <h2>選擇欄位</h2>
-        <div className="field-grid">
-          {FILTER_FIELDS.map(({ key, label }) => (
-            <label key={key} className="field-option">
-              <input
-                type="checkbox"
-                checked={filters.activeFields.includes(key)}
-                onChange={() => toggleField(key)}
-              />
-              <span>{label}</span>
-            </label>
-          ))}
+    const versionsAfterModel = collectVersionOptions(deviceConfig, selections.vendor, nextModels).map(
+      (version) => version.name
+    );
+    const sanitizedVersions = selections.version.filter((version) => versionsAfterModel.includes(version));
+    const devicesAfterModel = collectDeviceDetailOptions(
+      deviceConfig,
+      selections.vendor,
+      nextModels,
+      sanitizedVersions
+    );
+
+    updateSelections({
+      vendor: selections.vendor,
+      model: nextModels,
+      version: sanitizedVersions,
+      "machine.ip": selections["machine.ip"].filter((ip) => devicesAfterModel.some((d) => d.ip === ip)),
+      "machine.serial": selections["machine.serial"].filter((serial) =>
+        devicesAfterModel.some((d) => d.serial === serial)
+      ),
+      "machine.port": selections["machine.port"].filter((port) =>
+        devicesAfterModel.some((d) => String(d.port) === port)
+      ),
+    });
+  };
+
+  const handleVersionToggle = (version: string) => {
+    const nextVersions = selections.version.includes(version)
+      ? selections.version.filter((item) => item !== version)
+      : [...selections.version, version];
+
+    const devicesAfterVersion = collectDeviceDetailOptions(
+      deviceConfig,
+      selections.vendor,
+      selections.model,
+      nextVersions
+    );
+
+    updateSelections({
+      vendor: selections.vendor,
+      model: selections.model,
+      version: nextVersions,
+      "machine.ip": selections["machine.ip"].filter((ip) => devicesAfterVersion.some((d) => d.ip === ip)),
+      "machine.serial": selections["machine.serial"].filter((serial) =>
+        devicesAfterVersion.some((d) => d.serial === serial)
+      ),
+      "machine.port": selections["machine.port"].filter((port) =>
+        devicesAfterVersion.some((d) => String(d.port) === port)
+      ),
+    });
+  };
+
+  const renderDeviceOptions = () => {
+    return (
+      <div className="filter-section__body">
+        <div className="option-group">
+          <p className="option-group__title">廠商 (Vendor)</p>
+          <div className="option-grid">
+            {vendorOptions.map((vendor) => {
+              const checked = selections.vendor.includes(vendor.vendor);
+              return (
+                <label key={vendor.vendor} className="option-chip">
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    onChange={() => handleVendorToggle(vendor.vendor)}
+                  />
+                  <span>{vendor.vendor}</span>
+                </label>
+              );
+            })}
+          </div>
         </div>
-      </div>
 
-      {filters.activeFields.length > 0 && (
-        <div className="filter-section">
-          <h2>欄位內容</h2>
-          <div className="field-inputs">
-            {filters.activeFields.map((field) => (
-              <label key={field} className="input-group">
-                <span>{FILTER_FIELDS.find((item) => item.key === field)?.label ?? field}</span>
+        <div className="option-group">
+          <p className="option-group__title">型號 (Model)</p>
+          {selections.vendor.length === 0 && (
+            <p className="option-hint">請先選擇至少一個廠商。</p>
+          )}
+          <div className="option-grid" aria-disabled={selections.vendor.length === 0}>
+            {modelOptions.map((model) => (
+              <label key={`${model.vendor}-${model.name}`} className="option-chip">
                 <input
-                  type="text"
-                  value={filters.fieldValues[field] ?? ""}
-                  onChange={(event) => updateFieldValue(field, event.target.value)}
-                  placeholder="輸入關鍵字"
+                  type="checkbox"
+                  checked={selections.model.includes(model.name)}
+                  onChange={() => handleModelToggle(model.name)}
+                  disabled={selections.vendor.length === 0}
                 />
+                <span>{model.name}</span>
               </label>
             ))}
           </div>
         </div>
-      )}
 
-      <div className="filter-section">
-        <h2>時間範圍</h2>
-        <div className="date-grid">
-          {(["enqueued_at", "started_at", "completed_at"] as const).map((field) => (
-            <div key={field} className="date-group">
-              <span className="group-label">
-                {field === "enqueued_at" && "排入佇列時間"}
-                {field === "started_at" && "開始時間"}
-                {field === "completed_at" && "完成時間"}
-              </span>
-              <div className="date-inputs">
+        <div className="option-group">
+          <p className="option-group__title">版本 (Version)</p>
+          {selections.model.length === 0 && (
+            <p className="option-hint">請先選擇至少一個型號。</p>
+          )}
+          <div className="option-grid" aria-disabled={selections.model.length === 0}>
+            {versionOptions.map((version) => (
+              <label key={`${version.vendor}-${version.model}-${version.name}`} className="option-chip">
                 <input
-                  type="datetime-local"
-                  value={filters.dateRanges[field].from ?? ""}
-                  onChange={(event) => updateDate(field, "from", event.target.value)}
+                  type="checkbox"
+                  checked={selections.version.includes(version.name)}
+                  onChange={() => handleVersionToggle(version.name)}
+                  disabled={selections.model.length === 0}
                 />
-                <span className="delimiter">至</span>
-                <input
-                  type="datetime-local"
-                  value={filters.dateRanges[field].to ?? ""}
-                  onChange={(event) => updateDate(field, "to", event.target.value)}
-                />
+                <span>{version.name}</span>
+              </label>
+            ))}
+          </div>
+        </div>
+
+        <div className="option-group">
+          <p className="option-group__title">設備細節</p>
+          {selections.version.length === 0 && (
+            <p className="option-hint">請先選擇版本後即可指定設備細節。</p>
+          )}
+          <div className="device-detail-grid" aria-disabled={selections.version.length === 0}>
+            <div className="device-detail-column">
+              <h4>IP 位址</h4>
+              <div className="option-grid">
+                {availableIps.map((ip) => (
+                  <label key={ip} className="option-chip">
+                    <input
+                      type="checkbox"
+                      checked={selections["machine.ip"].includes(ip)}
+                      onChange={() => toggleDeviceValue("machine.ip", ip)}
+                      disabled={selections.version.length === 0}
+                    />
+                    <span>{ip}</span>
+                  </label>
+                ))}
               </div>
             </div>
-          ))}
+            <div className="device-detail-column">
+              <h4>序號</h4>
+              <div className="option-grid">
+                {availableSerials.map((serial) => (
+                  <label key={serial} className="option-chip">
+                    <input
+                      type="checkbox"
+                      checked={selections["machine.serial"].includes(serial)}
+                      onChange={() => toggleDeviceValue("machine.serial", serial)}
+                      disabled={selections.version.length === 0}
+                    />
+                    <span>{serial}</span>
+                  </label>
+                ))}
+              </div>
+            </div>
+            <div className="device-detail-column">
+              <h4>Port</h4>
+              <div className="option-grid">
+                {availablePorts.map((port) => (
+                  <label key={port} className="option-chip">
+                    <input
+                      type="checkbox"
+                      checked={selections["machine.port"].includes(port)}
+                      onChange={() => toggleDeviceValue("machine.port", port)}
+                      disabled={selections.version.length === 0}
+                    />
+                    <span>{port}</span>
+                  </label>
+                ))}
+              </div>
+            </div>
+          </div>
         </div>
       </div>
+    );
+  };
 
-      <div className="filter-section">
-        <h2>內容搜尋</h2>
-        <div className="text-grid">
-          <label className="input-group">
-            <span>Result Data</span>
-            <textarea
-              rows={3}
-              value={filters.resultData}
-              onChange={(event) => onChange({ ...filters, resultData: event.target.value })}
-              placeholder="輸入結果內容關鍵字"
-              spellCheck={false}
+  const renderTextFieldOptions = () => (
+    <div className="filter-section__body">
+      {TEXT_FIELDS.map(({ key, label, placeholder }) => (
+        <label key={key} className="input-row">
+          <span>{label}</span>
+          <input
+            type="text"
+            value={filters.fieldValues[key] ?? ""}
+            onChange={(event) => updateTextField(key, event.target.value)}
+            placeholder={placeholder}
+          />
+        </label>
+      ))}
+    </div>
+  );
+
+  const renderDateOptions = () => (
+    <div className="filter-section__body date-body">
+      {(["enqueued_at", "started_at", "completed_at"] as const).map((field) => (
+        <div key={field} className="date-row">
+          <div className="date-label">
+            {field === "enqueued_at" && "排入佇列時間"}
+            {field === "started_at" && "開始時間"}
+            {field === "completed_at" && "完成時間"}
+          </div>
+          <div className="date-inputs">
+            <input
+              type="datetime-local"
+              value={filters.dateRanges[field].from ?? ""}
+              onChange={(event) => updateDate(field, "from", event.target.value)}
             />
-          </label>
-          <label className="input-group">
-            <span>Switch Config (raw_data)</span>
-            <textarea
-              rows={3}
-              value={filters.rawData}
-              onChange={(event) => onChange({ ...filters, rawData: event.target.value })}
-              placeholder="輸入設定內容關鍵字"
-              spellCheck={false}
+            <span className="delimiter">至</span>
+            <input
+              type="datetime-local"
+              value={filters.dateRanges[field].to ?? ""}
+              onChange={(event) => updateDate(field, "to", event.target.value)}
             />
-          </label>
+          </div>
+          {dateErrors[field] && <p className="error-text">{dateErrors[field]}</p>}
         </div>
-      </div>
+      ))}
+    </div>
+  );
 
-      <div className="filter-actions">
-        <button type="button" onClick={onSubmit} disabled={submitting}>
-          {submitting ? "搜尋中..." : "送出查詢"}
+  const renderAdvancedOptions = () => (
+    <div className="filter-section__body advanced-body">
+      <p>大量文字貼上請使用下方按鈕開啟輸入視窗：</p>
+      <div className="advanced-actions">
+        <button type="button" onClick={() => setActiveTextModal("result")}>
+          編輯 Result Data
+        </button>
+        <button type="button" onClick={() => setActiveTextModal("raw")}>
+          編輯 Switch Config (raw data)
         </button>
       </div>
-    </section>
+    </div>
+  );
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="filter-menu" role="dialog" aria-modal="true">
+      <div className="filter-menu__backdrop" onClick={onClose} aria-hidden="true" />
+      <div className="filter-menu__container">
+        <header className="filter-menu__header">
+          <div>
+            <h1>Switch Ticket Explorer</h1>
+            <p>利用多層篩選器快速鎖定需要的 ticket。</p>
+          </div>
+          <button type="button" className="icon-button" onClick={onClose} aria-label="關閉篩選選單">
+            ×
+          </button>
+        </header>
+
+        <div className="filter-menu__content">
+          <div className="filter-section">
+            <button
+              type="button"
+              className={`section-toggle ${openSections.includes("device") ? "open" : ""}`}
+              onClick={() => toggleSection("device")}
+            >
+              <span>設備條件</span>
+              <span className="section-toggle__icon" aria-hidden="true" />
+            </button>
+            {openSections.includes("device") && (
+              <div className="section-panel">
+                {deviceLoading && <p className="option-hint">載入設備資料中...</p>}
+                {deviceError && <p className="error-text">{deviceError}</p>}
+                {!deviceLoading && !deviceError && renderDeviceOptions()}
+              </div>
+            )}
+          </div>
+
+          <div className="filter-section">
+            <button
+              type="button"
+              className={`section-toggle ${openSections.includes("fields") ? "open" : ""}`}
+              onClick={() => toggleSection("fields")}
+            >
+              <span>欄位搜尋</span>
+              <span className="section-toggle__icon" aria-hidden="true" />
+            </button>
+            {openSections.includes("fields") && <div className="section-panel">{renderTextFieldOptions()}</div>}
+          </div>
+
+          <div className="filter-section">
+            <button
+              type="button"
+              className={`section-toggle ${openSections.includes("dates") ? "open" : ""}`}
+              onClick={() => toggleSection("dates")}
+            >
+              <span>時間範圍</span>
+              <span className="section-toggle__icon" aria-hidden="true" />
+            </button>
+            {openSections.includes("dates") && <div className="section-panel">{renderDateOptions()}</div>}
+          </div>
+
+          <div className="filter-section">
+            <button
+              type="button"
+              className={`section-toggle ${openSections.includes("advanced") ? "open" : ""}`}
+              onClick={() => toggleSection("advanced")}
+            >
+              <span>進階內容</span>
+              <span className="section-toggle__icon" aria-hidden="true" />
+            </button>
+            {openSections.includes("advanced") && (
+              <div className="section-panel">{renderAdvancedOptions()}</div>
+            )}
+          </div>
+        </div>
+
+        <footer className="filter-menu__footer">
+          <button type="button" onClick={onSubmit} disabled={submitting}>
+            {submitting ? "搜尋中..." : "套用條件"}
+          </button>
+        </footer>
+      </div>
+
+      <TextEntryModal
+        open={activeTextModal === "result"}
+        title="編輯 Result Data"
+        value={filters.resultData}
+        onClose={() => setActiveTextModal(null)}
+        onSave={(value) => {
+          onChange({ ...filters, resultData: value });
+          setActiveTextModal(null);
+        }}
+      />
+      <TextEntryModal
+        open={activeTextModal === "raw"}
+        title="編輯 Switch Config (raw data)"
+        value={filters.rawData}
+        onClose={() => setActiveTextModal(null)}
+        onSave={(value) => {
+          onChange({ ...filters, rawData: value });
+          setActiveTextModal(null);
+        }}
+      />
+    </div>
   );
 }

--- a/frontend/src/components/TextEntryModal.css
+++ b/frontend/src/components/TextEntryModal.css
@@ -1,0 +1,83 @@
+.text-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  display: grid;
+  place-items: center;
+}
+
+.text-modal__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(9, 12, 18, 0.72);
+  backdrop-filter: blur(6px);
+}
+
+.text-modal__container {
+  position: relative;
+  width: min(720px, 94vw);
+  height: min(70vh, 520px);
+  background: #101522;
+  color: #f6f7fb;
+  border-radius: 24px;
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 36px 70px rgba(8, 12, 24, 0.6);
+}
+
+.text-modal__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.text-modal__header h2 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.text-modal__body {
+  flex: 1;
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}
+
+.text-modal__body textarea {
+  width: 100%;
+  height: 100%;
+  resize: none;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 16px;
+  background: rgba(5, 7, 12, 0.6);
+  color: inherit;
+  font-family: "JetBrains Mono", "Noto Sans Mono", monospace;
+  font-size: 0.95rem;
+  padding: 1rem 1.25rem;
+  line-height: 1.5;
+  overflow: auto;
+}
+
+.text-modal__footer {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.text-modal__footer button {
+  border: 0;
+  border-radius: 999px;
+  padding: 0.7rem 1.8rem;
+  background: linear-gradient(135deg, #ff4f5a, #e60012);
+  color: #fff;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  cursor: pointer;
+  box-shadow: 0 18px 32px rgba(230, 0, 18, 0.38);
+}
+
+@media (max-width: 640px) {
+  .text-modal__container {
+    padding: 1.5rem 1.1rem;
+  }
+}

--- a/frontend/src/components/TextEntryModal.tsx
+++ b/frontend/src/components/TextEntryModal.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useRef, useState } from "react";
+import "./TextEntryModal.css";
+
+interface TextEntryModalProps {
+  open: boolean;
+  title: string;
+  value: string;
+  onSave: (value: string) => void;
+  onClose: () => void;
+}
+
+export function TextEntryModal({ open, title, value, onSave, onClose }: TextEntryModalProps) {
+  const [draft, setDraft] = useState<string>(value);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setDraft(value);
+    }
+  }, [open, value]);
+
+  useEffect(() => {
+    if (open && textareaRef.current) {
+      textareaRef.current.focus();
+    }
+  }, [open]);
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div className="text-modal" role="dialog" aria-modal="true">
+      <div className="text-modal__backdrop" onClick={onClose} aria-hidden="true" />
+      <div className="text-modal__container">
+        <header className="text-modal__header">
+          <h2>{title}</h2>
+          <button type="button" className="icon-button" onClick={onClose} aria-label="關閉大量文字輸入">
+            ×
+          </button>
+        </header>
+        <div className="text-modal__body">
+          <textarea
+            ref={textareaRef}
+            value={draft}
+            onChange={(event) => setDraft(event.target.value)}
+            spellCheck={false}
+            placeholder="請在此貼上完整內容"
+          />
+        </div>
+        <footer className="text-modal__footer">
+          <button type="button" onClick={() => onSave(draft)}>
+            儲存
+          </button>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useDeviceOptions.ts
+++ b/frontend/src/hooks/useDeviceOptions.ts
@@ -1,0 +1,56 @@
+import { useEffect, useState } from "react";
+import type { DeviceConfig } from "../types";
+
+const API_PATH = "/devices/options";
+const DEFAULT_BASE_URL = "http://localhost:8000";
+
+async function requestDeviceOptions(): Promise<DeviceConfig | null> {
+  const baseUrl = import.meta.env.VITE_API_BASE_URL ?? DEFAULT_BASE_URL;
+
+  const response = await fetch(`${baseUrl}${API_PATH}`);
+  if (!response.ok) {
+    throw new Error(`Request failed with status ${response.status}`);
+  }
+
+  const data = (await response.json()) as DeviceConfig | null;
+  return data;
+}
+
+export function useDeviceOptions() {
+  const [options, setOptions] = useState<DeviceConfig | null>(null);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+    setLoading(true);
+    setError(null);
+
+    requestDeviceOptions()
+      .then((data) => {
+        if (!isMounted) {
+          return;
+        }
+        setOptions(data);
+      })
+      .catch((err: unknown) => {
+        console.error(err);
+        if (!isMounted) {
+          return;
+        }
+        setError("無法載入設備選項，請稍後再試。");
+        setOptions(null);
+      })
+      .finally(() => {
+        if (isMounted) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  return { options, loading, error };
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,18 +1,10 @@
 :root {
   font-family: "Inter", "Noto Sans TC", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
     sans-serif;
-  color-scheme: light dark;
+  color-scheme: light;
   line-height: 1.6;
-  --tsmc-red: #ef3340;
-  --tsmc-blue: #005daa;
-  --tsmc-navy: #0c1a2e;
-  --tsmc-light: #f5f6fa;
-  --surface: #ffffff;
-  --surface-muted: #f1f4f9;
-  --ink: #233047;
-  --ink-strong: #161f2f;
-  --ink-muted: #5c667a;
-  background-color: #070c1a;
+  background-color: #f7f8fb;
+  color: #1a1c2d;
 }
 
 * {
@@ -22,7 +14,7 @@
 body {
   margin: 0;
   min-height: 100vh;
-  background-color: #070c1a;
+  background-color: #f7f8fb;
 }
 
 a {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -45,3 +45,28 @@ export interface FilterState {
   resultData: string;
   rawData: string;
 }
+
+export interface DeviceEntryOption {
+  ip: string;
+  port: number;
+  serial_number: string;
+}
+
+export interface VersionOption {
+  version: string;
+  devices: DeviceEntryOption[];
+}
+
+export interface ModelOption {
+  model: string;
+  versions: VersionOption[];
+}
+
+export interface VendorOption {
+  vendor: string;
+  models: ModelOption[];
+}
+
+export interface DeviceConfig {
+  vendors: VendorOption[];
+}


### PR DESCRIPTION
## Summary
- introduce a /devices/options API endpoint to surface structured device selections to the frontend
- redesign the React layout with a TSMC-inspired top bar, hamburger filter launcher, and collapsible filter menu
- add hierarchical device filters, date validation, and modal editors for large text inputs in the new menu

## Testing
- `npm install` *(fails: registry access returned 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d878e778f883338f3c6d6ca2487d16